### PR TITLE
fix: prevent duplicate cart modals on mobile

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,12 +2,14 @@
 import AccountDashboard from './accountdashboard.astro';
 import MobileMenu from '@components/navbar/mobile-menu';
 import CartEntry from '@/components/cart/CartEntry.tsx';
+import CartButton from '@/components/cart/cart-button.tsx';
 import { SearchBar } from '@components/SearchBar.tsx';
 
 ---
 
 <header class="bg-black/80 shadow-xl shadow-outline text-white w-full pt-[40px]">
-  
+  <CartEntry client:load />
+
   <!-- Top Red Bar (always visible) -->
 <div id="topRedBar" class="hidden md:block fixed top-0 w-full h-6 bg-primary text-white z-[50]">
   <div class="max-w-screen-xl mx-auto px-6 flex pt-2 items-center justify-between">
@@ -44,7 +46,7 @@ import { SearchBar } from '@components/SearchBar.tsx';
     <!-- Right side: Mobile Search + Cart -->
     <div class="flex items-center gap-3" id="mobileHeaderRight">
       <!-- Cart trigger (uses global CartProvider) -->
-      <CartEntry client:load />
+      <CartButton client:load />
     </div>
   </div>
 </div>
@@ -73,7 +75,7 @@ import { SearchBar } from '@components/SearchBar.tsx';
       </div>
       <div class="flex justify-end items-center">
         <!-- Cart Modal Trigger (desktop) -->
-        <CartEntry client:load />
+        <CartButton client:load />
         <div id="accountDashboardPanel" class="hidden fixed top-0 right-0 h-full w-[220px] bg-[#1a1a1a] transform translate-x-full transition-transform duration-300 ease-in-out z-[600] shadow-lg border-l border-white/10 slide-in pointer-events-auto">
           <h2 class="z-[10001] text-white mx-5 pt-12 font-borg-italic rem-1.5">ACCOUNT</h2>
           <button id="closeAccountDashboard" class="group absolute top-10 right-4 z-[10001] bg-transparent text-white p-2 rounded-full shadow hover:text-red-500 transition ai-style-change-1">

--- a/src/components/cart/cart-button.tsx
+++ b/src/components/cart/cart-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import OpenCart from './open-cart';
+import { CART_EVENT, getCart } from '@/lib/cart';
+
+export default function CartButton() {
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    const compute = () => {
+      const cart = getCart();
+      const qty = cart.reduce((sum, it) => sum + (it.quantity || 0), 0);
+      setTotal(qty);
+    };
+    compute();
+    function onChange(ev: any) {
+      try {
+        const items = ev.detail.cart.items || [];
+        const qty = items.reduce((sum: number, it: any) => sum + (it.quantity || 0), 0);
+        setTotal(qty);
+      } catch {
+        compute();
+      }
+    }
+    window.addEventListener(CART_EVENT as any, onChange as EventListener);
+    return () => window.removeEventListener(CART_EVENT as any, onChange as EventListener);
+  }, []);
+
+  const handleClick = () => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('open-cart'));
+    }
+  };
+
+  return (
+    <button aria-label="Open cart" onClick={handleClick}>
+      <OpenCart quantity={total} />
+    </button>
+  );
+}

--- a/src/components/cart/modal.tsx
+++ b/src/components/cart/modal.tsx
@@ -10,13 +10,11 @@ import { redirectToCheckout } from './actions';
 import { useCart } from './cart-context';
 import { DeleteItemButton } from './delete-item-button';
 import { EditItemQuantityButton } from './edit-item-quantity-button';
-import OpenCart from './open-cart';
 
 export default function CartModal() {
   const { cart, totalQuantity, subtotal } = useCart();
   const [isOpen, setIsOpen] = useState(false);
   const quantityRef = useRef(totalQuantity);
-  const openCart = () => setIsOpen(true);
   const closeCart = () => setIsOpen(false);
 
   useEffect(() => {
@@ -26,11 +24,16 @@ export default function CartModal() {
     }
   }, [isOpen, totalQuantity]);
 
+  useEffect(() => {
+    function handleOpen() {
+      setIsOpen(true);
+    }
+    window.addEventListener('open-cart' as any, handleOpen);
+    return () => window.removeEventListener('open-cart' as any, handleOpen);
+  }, []);
+
   return (
     <>
-      <button aria-label="Open cart" onClick={openCart}>
-        <OpenCart quantity={totalQuantity} />
-      </button>
       <Transition show={isOpen}>
         <Dialog onClose={closeCart} className="relative z-50">
           <Transition.Child
@@ -53,7 +56,7 @@ export default function CartModal() {
             leaveFrom="translate-x-0"
             leaveTo="translate-x-full"
           >
-            <Dialog.Panel className="fixed bottom-0 right-0 top-0 flex h-full w-full flex-col border-l border-neutral-200 bg-white/80 p-6 text-black backdrop-blur-xl md:w-[390px] dark:border-neutral-700 dark:bg-black/80 dark:text-white">
+            <Dialog.Panel className="fixed bottom-0 right-0 top-0 flex h-full w-full flex-col overflow-y-auto border-l border-neutral-200 bg-white/80 p-6 text-black backdrop-blur-xl md:w-[390px] dark:border-neutral-700 dark:bg-black/80 dark:text-white">
               <div className="flex items-center justify-between">
                 <p className="text-lg font-semibold">My Cart</p>
                 <button aria-label="Close cart" onClick={closeCart}>


### PR DESCRIPTION
## Summary
- add standalone cart button that dispatches `open-cart`
- listen for `open-cart` in cart modal and enable panel scrolling
- render a single cart provider and reuse cart button in header

## Testing
- `yarn lint` *(fails: Config (unnamed): Unexpected key "0" found)*

------
https://chatgpt.com/codex/tasks/task_e_68be875d86a0832cbc6d7bc3a330a630