### PR TITLE
Hide mobile add-to-cart bar when cart is open

### DIFF
--- a/src/components/cart/modal.tsx
+++ b/src/components/cart/modal.tsx
@@ -32,6 +32,13 @@ export default function CartModal() {
     return () => window.removeEventListener('open-cart' as any, handleOpen);
   }, []);
 
+  // Notify other components when the cart drawer opens or closes
+  useEffect(() => {
+    try {
+      window.dispatchEvent(new Event(isOpen ? 'cart:open' : 'cart:close'));
+    } catch {}
+  }, [isOpen]);
+
   return (
     <>
       <Transition show={isOpen}>

--- a/src/pages/shop/[slug].astro
+++ b/src/pages/shop/[slug].astro
@@ -474,7 +474,7 @@ try {
   
 </BaseLayout>
 <!-- Sticky mobile add-to-cart bar -->
-<div class="md:hidden fixed bottom-0 left-0 right-0 z-[60] bg-black/90 border-t border-white/10 backdrop-blur px-3 py-2 flex items-center justify-between">
+<div id="mobile-add-to-cart" class="md:hidden fixed bottom-0 left-0 right-0 z-[60] bg-black/90 border-t border-white/10 backdrop-blur px-3 py-2 flex items-center justify-between">
   <div class="text-white/90 text-sm">
     <span class="text-white/60">Total:</span>
     <span id="sticky-price" class="font-bold">$ {(typeof (product as any).price === 'number' ? (product as any).price.toFixed(2) : '0.00')}</span>
@@ -504,6 +504,18 @@ try {
       const mo = new MutationObserver(sync);
       mo.observe(main, { childList: true, characterData: true, subtree: true });
       sync();
+    } catch {}
+  })();
+
+  // Hide sticky bar when cart drawer is open
+  (function(){
+    try {
+      const bar = document.getElementById('mobile-add-to-cart');
+      if (!bar) return;
+      const hide = () => bar.classList.add('hidden');
+      const show = () => bar.classList.remove('hidden');
+      window.addEventListener('cart:open', hide);
+      window.addEventListener('cart:close', show);
     } catch {}
   })();
 </script>


### PR DESCRIPTION
## Summary
- dispatch cart open and close events from the modal
- hide mobile add-to-cart bar when the cart drawer is opened

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Config (unnamed): Unexpected key "0" found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe6e7b28c832c8edbec937c8e9a8e