### PR TITLE
Fix cart checkout redirection to Stripe

### DIFF
--- a/src/components/cart/actions.ts
+++ b/src/components/cart/actions.ts
@@ -121,7 +121,8 @@ export async function redirectToCheckout() {
     const res = await fetch('/api/checkout', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cart })
+      // API expects an array of cart items; send cart.items instead of entire cart object
+      body: JSON.stringify({ cart: cart.items })
     });
     if (!res.ok) throw new Error('Checkout failed');
     const data = await res.json();


### PR DESCRIPTION
## Summary
- fix Stripe checkout call by sending cart items array

## Testing
- `yarn lint` (fails: ConfigError: Unexpected key "0" found)
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bfe7e64f60832cbfe4daff53b8a2f3