### PR TITLE
fix: allow vertical scrolling on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -565,9 +565,7 @@
     scrollbar-width: none;
     -ms-overflow-style: none;
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior-x: contain;
     scroll-snap-type: x mandatory; /* scroll snapping belongs on the scroll container */
-    touch-action: pan-x; /* allow horizontal swipe on touch devices */
   }
 
   .mobile-carousel::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- remove touch-action and overscroll-behavior from mobile carousel styles so vertical swipes scroll the page

## Testing
- `yarn lint` *(fails: Config (unnamed): Unexpected key "0" found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe8dcea00832cad7b90612608ee18