### PR TITLE
Adjust mobile padding and refine service page styles

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,46 +5,34 @@ import pluginReact from 'eslint-plugin-react';
 import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
-  // 1) Global ignores
   {
     ignores: [
       'dist/**/*',
       'node_modules/**/*',
       'public/**/*',
-      // Ignore the files that were blocking commits
       'src/components/BookingConfirm.jsx',
       'src/context/Auth0Provider.tsx',
       'src/pages/api/save-order.ts',
       'src/pages/api/save-quote.ts'
     ]
   },
-
-  // 2) Base JS rules
   {
     files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
-    plugins: { js },
-    extends: ['js/recommended']
+    ...js.configs.recommended
   },
-
-  // 3) Globals
   {
     files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
     languageOptions: { globals: { ...globals.browser, ...globals.node } }
   },
-
-  // 4) TypeScript recommended, plus plugin registration and rule relaxations
+  ...tseslint.configs.recommended,
   {
     files: ['**/*.{ts,tsx}'],
-    ...tseslint.configs.recommended,
     plugins: { '@typescript-eslint': tseslint.plugin },
     rules: {
-      // Turn off the blockers:
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': ['off']
+      '@typescript-eslint/no-unused-vars': 'off'
     }
   },
-
-  // 5) React rules, relaxed
   {
     ...pluginReact.configs.flat.recommended,
     settings: { react: { version: 'detect' } },
@@ -52,7 +40,6 @@ export default defineConfig([
       ...pluginReact.configs.flat.recommended.rules,
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
-      // Stop failing on apostrophes and similar
       'react/no-unescaped-entities': 'off'
     }
   }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,7 +25,7 @@ import { Toaster } from 'sonner';
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   </head>
 
-  <body class="bg-background pt-3 px-5 text-white font-mono min-h-screen flex flex-col">
+  <body class="bg-background pt-3 text-white font-mono min-h-screen flex flex-col">
     <!-- Global SVG filters for Liquid Glass effect -->
     <svg width="0" height="0" class="absolute pointer-events-none select-none" aria-hidden="true" focusable="false">
       <defs>
@@ -50,7 +50,7 @@ import { Toaster } from 'sonner';
     <CartProvider client:load>
        <div class="relative z-10">
       <Header />
-      <main class="mt-10 pt-5 flex-grow container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">
+      <main class="mt-10 pt-5 flex-grow container max-w-7xl">
         <slot />
       </main>
       <Footer />

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -21,10 +21,10 @@ const slots = data?.bookings || [];
     )}
 
     <!-- HERO -->
-    <section class="relative overflow-hidden">
-      <div class="absolute w-[480px] h-[340px] -left-40 top-40 bg-primary blur-[80px] opacity-50 rounded-full"></div>
-      <div class="absolute w-[360px] h-[560px] right-10 -top-24 bg-white/70 blur-[90px] opacity-50 rounded-full"></div>
-      <div class="relative max-w-7xl mx-auto px-6 md:px-10 py-16 md:py-24">
+      <section class="relative overflow-hidden">
+        <div class="absolute w-[480px] h-[340px] -left-40 top-40 bg-primary blur-[80px] opacity-50 rounded-full"></div>
+        <div class="absolute w-[360px] h-[560px] right-10 -top-24 bg-white/70 blur-[90px] opacity-50 rounded-full"></div>
+        <div class="relative container max-w-7xl py-16 md:py-24">
         <p class="text-[#FFA800] font-mono font-bold text-xl tracking-wide mb-2">Appointment Booking</p>
         <h1 class="text-white font-ethno text-4xl md:text-6xl leading-tight mb-4" {...sbFieldPath('title')}>
           {pageDoc?.title ?? 'Schedule Your Install'}
@@ -40,8 +40,8 @@ const slots = data?.bookings || [];
     </section>
 
     <!-- PROMISE STRIP -->
-    <section class="bg-black/70 border-y border-white/20">
-      <div class="max-w-7xl mx-auto px-6 md:px-10 py-4 grid grid-cols-2 md:grid-cols-4 gap-2">
+      <section class="bg-black/70 border-y border-white/20">
+        <div class="container max-w-7xl py-4 grid grid-cols-2 md:grid-cols-4 gap-2">
         <div class="flex items-center gap-3"><span class="w-2 h-2 rounded-full bg-[#FFA800]"></span><span class="text-white/80 text-sm font-mono tracking-[0.14em]">Warranty‑friendly</span></div>
         <div class="flex items-center gap-3"><span class="w-2 h-2 rounded-full bg-[#FFA800]"></span><span class="text-white/80 text-sm font-mono tracking-[0.14em]">OEM‑level fit</span></div>
         <div class="flex items-center gap-3"><span class="w-2 h-2 rounded-full bg-[#FFA800]"></span><span class="text-white/80 text-sm font-mono tracking-[0.14em]">Up‑front pricing</span></div>
@@ -50,8 +50,8 @@ const slots = data?.bookings || [];
     </section>
 
     <!-- CAL.COM EMBED WRAPPER -->
-    <section id="book" class="px-6 md:px-10 py-12">
-      <div class="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <section id="book" class="py-12">
+        <div class="container max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-6">
         <!-- Calendar card -->
         <div class="lg:col-span-2">
           <div class="rounded-xl border border-white/20 bg-[#0b0b0c]/90 shadow-xl shadow-black/40 overflow-hidden">
@@ -97,9 +97,9 @@ const slots = data?.bookings || [];
     </section>
 
     <!-- RECENT BOOKINGS (optional, if token present) -->
-    {slots.length > 0 && (
-      <section class="px-6 md:px-10 pb-6 -mt-2">
-        <div class="max-w-7xl mx-auto">
+      {slots.length > 0 && (
+        <section class="pb-6 -mt-2">
+          <div class="container max-w-7xl">
           <h2 class="text-white font-ethno text-2xl mb-4">Recent bookings</h2>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {slots.map((slot: any) => (
@@ -118,8 +118,8 @@ const slots = data?.bookings || [];
     )}
 
     <!-- FAQ -->
-    <section id="faq" class="px-6 md:px-10 py-12">
-      <div class="max-w-5xl mx-auto">
+      <section id="faq" class="py-12">
+        <div class="container max-w-5xl">
         <h2 class="text-white font-borg text-3xl mb-6">FAQs</h2>
         <div class="divide-y divide-white/80 border border-white/20 rounded-xl overflow-hidden">
           <details class="group open:bg-black/50">

--- a/src/pages/services/customFab.astro
+++ b/src/pages/services/customFab.astro
@@ -14,7 +14,7 @@ const pageDoc: any = await getGitPageDoc('customFab');
   )}
 
   <!-- HERO -->
-  <section class="parallax-section section-divider section-divider-carbon"> 
+  <section class="parallax-section custom-hero section-divider section-divider-carbon">
     <div class="background-layer">
       <img
         src="/images/fabrication/FAS-Fabrication-1.png"
@@ -23,7 +23,7 @@ const pageDoc: any = await getGitPageDoc('customFab');
         loading="eager"
       />
     </div>
-    <div class="foreground-layer">
+    <div class="foreground-layer !pt-32 md:!pt-40">
       <h1 class="text-4xl md:text-6xl font-ethno text-accent drop-shadow mb-3" {...sbFieldPath('title')}>
         {pageDoc?.title ?? 'Custom Fabrication & Welding'}
       </h1>
@@ -189,3 +189,15 @@ const pageDoc: any = await getGitPageDoc('customFab');
     <Hero client:load />
   </section>
 </BaseLayout>
+
+<style>
+  .custom-hero {
+    height: 60vh;
+  }
+
+  @media (min-width: 768px) {
+    .custom-hero {
+      height: 80vh;
+    }
+  }
+</style>

--- a/src/pages/services/porting.astro
+++ b/src/pages/services/porting.astro
@@ -58,19 +58,19 @@ const portingItems = [
       <div class="grid grid-cols-2 md:grid-cols-4 gap-0">
         <div class="flex items-center gap-3 py-4 px-4 border-r border-white/20">
           <div class="w-2 h-2 rounded-full bg-accent"></div>
-          <div class="text-white/80 text-xs md:text-sm font-mono tracking-[0.14em]">Flow‑Bench Guided</div>
+          <div class="text-white text-xs md:text-sm font-mono tracking-[0.14em]">Flow‑Bench Guided</div>
         </div>
         <div class="flex items-center gap-3 py-4 px-4 border-r border-white/20">
           <div class="w-2 h-2 rounded-full bg-accent"></div>
-          <div class="text-white/80 text-xs md:text-sm font-mono tracking-[0.14em]">CNC &amp; Hand‑Finish</div>
+          <div class="text-white text-xs md:text-sm font-mono tracking-[0.14em]">CNC &amp; Hand‑Finish</div>
         </div>
         <div class="flex items-center gap-3 py-4 px-4 border-r border-white/20">
           <div class="w-2 h-2 rounded-full bg-accent"></div>
-          <div class="text-white/80 text-xs md:text-sm font-mono tracking-[0.14em]">Matched Components</div>
+          <div class="text-white text-xs md:text-sm font-mono tracking-[0.14em]">Matched Components</div>
         </div>
         <div class="flex items-center gap-3 py-4 px-4">
           <div class="w-2 h-2 rounded-full bg-accent"></div>
-          <div class="text-white/80 text-xs md:text-sm font-mono tracking-[0.14em]">OEM‑Level Fit &amp; Finish</div>
+          <div class="text-white text-xs md:text-sm font-mono tracking-[0.14em]">OEM‑Level Fit &amp; Finish</div>
         </div>
       </div>
     </div>
@@ -78,22 +78,22 @@ const portingItems = [
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3 py-4">
         <div class="rounded-lg border border-white/20 bg-black/50 p-3 text-center">
           <div class="text-2xl font-borg text-white">±0.5%</div>
-          <div class="text-xs text-white/70">CSA variance target</div>
+          <div class="text-xs text-white">CSA variance target</div>
         </div>
         <div class="rounded-lg border border-white/20 bg-black/50 p-3 text-center">
           <div class="text-2xl font-borg text-white">≤0.001"</div>
-          <div class="text-xs text-white/70">Flatness at flanges</div>
+          <div class="text-xs text-white">Flatness at flanges</div>
         </div>
         <div class="rounded-lg border border-white/20 bg-black/50 p-3 text-center">
           <div class="text-2xl font-borg text-white">20–40+ whp</div>
-          <div class="text-xs text-white/70">Typical SC gains*</div>
+          <div class="text-xs text-white">Typical SC gains*</div>
         </div>
         <div class="rounded-lg border border-white/20 bg-black/50 p-3 text-center">
           <div class="text-2xl font-borg text-white">Bench‑guided</div>
-          <div class="text-xs text-white/70">Validation process</div>
+          <div class="text-xs text-white">Validation process</div>
         </div>
       </div>
-      <p class="text-white/70 text-[11px] pb-4">* With proper tuning and supporting mods. Results vary by platform.</p>
+      <p class="text-white/80 text-[11px] pb-4">* With proper tuning and supporting mods. Results vary by platform.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- move horizontal spacing to BaseLayout using container
- drop redundant padding from schedule page sections
- improve overview strip contrast on porting page
- scale custom fabrication hero banner for better fit
- clean up ESLint flat config for linting

## Testing
- `yarn lint` *(fails: 111 problems, 109 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eebc9540832cb399ba7ac2e35909