### PR TITLE
Add redirects for legacy product routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,16 @@
   status = 200
 
 [[redirects]]
+  from = "/products/*"
+  to = "/shop/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/product-category/*"
+  to = "/shop/categories/:splat"
+  status = 301
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
## Summary
- add a permanent redirect from the legacy `/products/*` path to the new `/shop/:splat` route
- add a permanent redirect from the legacy `/product-category/*` path to `/shop/categories/:splat`

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f6945eb0fc832c9e4ed94a29a57157