### PR TITLE
Protect API error responses from indexing

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -20,3 +20,7 @@
 /fonts/*.otf
   Content-Type: font/otf
   Access-Control-Allow-Origin: *
+
+/api/*
+  X-Robots-Tag: noindex, nofollow
+  Cache-Control: no-store, max-age=0, must-revalidate

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,9 @@
 User-agent: *
 Allow: /
+Disallow: /api/
+Disallow: /account
+Disallow: /dashboard
+Disallow: /vendor
 Sitemap: https://www.fasmotorsports.com/sitemap_index.xml
 Sitemap: https://www.fasmotorsports.com/sitemap.xml
 

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import bcrypt from 'bcryptjs';
 // Defer importing Sanity utilities until we know env is configured
 import { setSession } from '../../../server/auth/session';
+import { jsonResponse } from '@/server/http/responses';
 
 // POST /api/auth/login
 // Body: { email: string, password: string }
@@ -11,10 +12,7 @@ export const POST: APIRoute = async ({ request }) => {
     const email = String(body?.email || '').trim().toLowerCase();
     const password = String(body?.password || '');
     if (!email || !password) {
-      return new Response(JSON.stringify({ message: 'Missing email or password' }), {
-        status: 400,
-        headers: { 'content-type': 'application/json' }
-      });
+      return jsonResponse({ message: 'Missing email or password' }, { status: 400 });
     }
 
     const adminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase();
@@ -88,20 +86,14 @@ export const POST: APIRoute = async ({ request }) => {
       const message = accountFound
         ? 'Incorrect password. Double-check your password or use “Forgot password” to reset it.'
         : 'We couldn’t find an account with that email. Create one or verify you entered it correctly.';
-      return new Response(JSON.stringify({ message }), {
-        status: 401,
-        headers: { 'content-type': 'application/json' }
-      });
+      return jsonResponse({ message }, { status: 401 }, { noIndex: true });
     }
 
     const headers = new Headers({ 'content-type': 'application/json' });
     setSession(headers, sessionUser, expiresInSeconds ? { expiresIn: expiresInSeconds } : {});
-    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+    return jsonResponse({ ok: true }, { status: 200, headers });
   } catch (err) {
     console.error(err);
-    return new Response(JSON.stringify({ message: 'Internal server error' }), {
-      status: 500,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse({ message: 'Internal server error' }, { status: 500 });
   }
 };

--- a/src/pages/api/get-customer-profile.ts
+++ b/src/pages/api/get-customer-profile.ts
@@ -2,6 +2,7 @@
 import type { APIRoute } from 'astro';
 import { sanityClient } from '@/lib/sanityClient';
 import { readSession } from '../../server/auth/session';
+import { jsonResponse } from '@/server/http/responses';
 
 function getBearer(req: Request): string | null {
   const auth = req.headers.get('authorization') || '';
@@ -36,10 +37,10 @@ export const GET: APIRoute = async ({ request }) => {
     const email = (session?.user?.email as string) || '';
 
     if (!sub && !email) {
-      return new Response(JSON.stringify({ message: 'Token missing sub/email' }), {
-        status: 400,
-        headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' }
-      });
+      return jsonResponse(
+        { message: 'Token missing sub/email' },
+        { status: 400, headers: { 'access-control-allow-origin': '*' } }
+      );
     }
 
     // Prefer lookup by authId (sub), then fallback to email
@@ -54,21 +55,22 @@ export const GET: APIRoute = async ({ request }) => {
     }
 
     if (!customer) {
-      return new Response(JSON.stringify({ message: 'Customer not found' }), {
-        status: 404,
-        headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' }
-      });
+      return jsonResponse(
+        { message: 'Customer not found' },
+        { status: 404, headers: { 'access-control-allow-origin': '*' } }
+      );
     }
 
-    return new Response(JSON.stringify(customer), {
+    return jsonResponse(customer, {
       status: 200,
-      headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' }
+      headers: { 'access-control-allow-origin': '*' }
     });
   } catch (err) {
     console.error('get-customer-profile error:', err);
-    return new Response(JSON.stringify({ message: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' }
-    });
+    return jsonResponse(
+      { message: 'Unauthorized' },
+      { status: 401, headers: { 'access-control-allow-origin': '*' } },
+      { noIndex: true }
+    );
   }
 };

--- a/src/pages/api/vendor/dashboard.ts
+++ b/src/pages/api/vendor/dashboard.ts
@@ -1,35 +1,28 @@
 import type { APIRoute } from 'astro';
 import { readSession } from '../../../server/auth/session';
 import { getVendorOrdersByVendorId } from '../../../server/sanity-client';
+import { jsonResponse } from '@/server/http/responses';
 
 export const GET: APIRoute = async ({ request }) => {
   const { session } = await readSession(request);
   if (!session?.user) {
-    return new Response(JSON.stringify({ message: 'Authentication required' }), {
-      status: 401,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse(
+      { message: 'Authentication required' },
+      { status: 401 },
+      { noIndex: true }
+    );
   }
 
   const { id, roles } = session.user;
   if (!roles?.includes('vendor')) {
-    return new Response(JSON.stringify({ message: 'Unauthorized' }), {
-      status: 403,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse({ message: 'Unauthorized' }, { status: 403 });
   }
 
   try {
     const orders = await getVendorOrdersByVendorId(id);
-    return new Response(JSON.stringify({ orders }), {
-      status: 200,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse({ orders });
   } catch (err) {
     console.error(err);
-    return new Response(JSON.stringify({ message: 'Internal server error' }), {
-      status: 500,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse({ message: 'Internal server error' }, { status: 500 });
   }
 };

--- a/src/pages/api/vendor/me.ts
+++ b/src/pages/api/vendor/me.ts
@@ -1,24 +1,28 @@
 import type { APIRoute } from 'astro';
 import { readSession } from '../../../server/auth/session';
 import { getVendorBySub } from '../../../server/sanity-client';
+import { jsonResponse, withNoIndexHeaders } from '@/server/http/responses';
 
 export const GET: APIRoute = async ({ request }) => {
   const { session, status } = await readSession(request);
   if (!session?.user) {
-    return new Response('Unauthorized', { status: status ?? 401 });
+    return new Response('Unauthorized', {
+      status: status ?? 401,
+      headers: withNoIndexHeaders({ 'content-type': 'text/plain; charset=utf-8' })
+    });
   }
 
   try {
     const vendor = await getVendorBySub(session.user.id);
     if (!vendor) {
-      return new Response('Not Found', { status: 404 });
+      return new Response('Not Found', { status: 404, headers: { 'content-type': 'text/plain; charset=utf-8' } });
     }
-    return new Response(JSON.stringify(vendor), {
-      status: 200,
-      headers: { 'content-type': 'application/json' }
-    });
+    return jsonResponse(vendor);
   } catch (err) {
     console.error(err);
-    return new Response('Internal Server Error', { status: 500 });
+    return new Response('Internal Server Error', {
+      status: 500,
+      headers: { 'content-type': 'text/plain; charset=utf-8' }
+    });
   }
 };

--- a/src/pages/api/wheel-quote-update.ts
+++ b/src/pages/api/wheel-quote-update.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { z } from 'zod';
 import { createClient } from '@sanity/client';
+import { jsonResponse } from '@/server/http/responses';
 
 // Optional simple auth for server-to-server calls from your dashboard
 // Set FAS_DASH_API_KEY in Netlify. If present, requests must include header: Authorization: Bearer <key>
@@ -20,10 +21,7 @@ const BodySchema = z.object({
 });
 
 function unauthorized(msg = 'Unauthorized') {
-  return new Response(JSON.stringify({ error: msg }), {
-    status: 401,
-    headers: { 'Content-Type': 'application/json' }
-  });
+  return jsonResponse({ error: msg }, { status: 401 }, { noIndex: true });
 }
 
 export const OPTIONS: APIRoute = async () => new Response(null, { status: 204 });
@@ -42,16 +40,10 @@ export const PATCH: APIRoute = async ({ request }) => {
     // Update Sanity document
     const result = await sanity.patch(id).set({ status }).commit({ autoGenerateArrayKeys: true });
 
-    return new Response(JSON.stringify({ ok: true, id: result._id, status: result.status }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' }
-    });
+    return jsonResponse({ ok: true, id: result._id, status: result.status });
   } catch (err: any) {
     const message = err?.message || 'Invalid request';
-    return new Response(JSON.stringify({ error: message }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' }
-    });
+    return jsonResponse({ error: message }, { status: 400 });
   }
 };
 

--- a/src/server/http/responses.ts
+++ b/src/server/http/responses.ts
@@ -1,0 +1,48 @@
+export interface JsonResponseOptions {
+  /** When true, adds bot-blocking headers so crawlers ignore the response. */
+  noIndex?: boolean;
+  /** Explicit cache-control header to apply when noIndex is true. */
+  cacheControl?: string;
+}
+
+function applyNoIndexHeaders(headers: Headers, cacheControl?: string) {
+  if (!headers.has('cache-control')) {
+    headers.set('cache-control', cacheControl ?? 'no-store, max-age=0, must-revalidate');
+  }
+  headers.set('x-robots-tag', 'noindex, nofollow');
+}
+
+export function withNoIndexHeaders(
+  base?: HeadersInit,
+  { cacheControl }: { cacheControl?: string } = {}
+): Headers {
+  const headers = new Headers(base ?? {});
+  applyNoIndexHeaders(headers, cacheControl);
+  return headers;
+}
+
+export function jsonResponse(
+  data: unknown,
+  init: ResponseInit = {},
+  options: JsonResponseOptions = {}
+): Response {
+  const headers = new Headers(init.headers ?? {});
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+  if (options.noIndex) {
+    applyNoIndexHeaders(headers, options.cacheControl);
+  }
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers
+  });
+}
+
+export function unauthorizedJson(
+  data: unknown = { message: 'Unauthorized' },
+  init: ResponseInit = {},
+  options: JsonResponseOptions = {}
+): Response {
+  return jsonResponse(data, { status: 401, ...init }, { ...options, noIndex: true });
+}


### PR DESCRIPTION
## Summary
- add shared helpers to mark API responses as non-indexable and standardize JSON payloads
- apply the helpers across customer, vendor, and order endpoints so 401 responses emit `X-Robots-Tag` headers
- update robots and Netlify headers to disallow bots from crawling account, vendor, and API surfaces

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68f69824d5a4832c914ad0943952ecf6