### PR TITLE
Fix JSON-LD scripts to avoid HTML escaping

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -40,9 +40,7 @@ const structuredData = {
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/about.json')}>
     <!-- Inline-editable Page Title (mapped to content/pages/about.json:title) -->

--- a/src/pages/belak/wheels.astro
+++ b/src/pages/belak/wheels.astro
@@ -35,9 +35,7 @@ const breadcrumbStructuredData = {
 
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(breadcrumbStructuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
   </Fragment>
 
  <BelakHero

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -39,9 +39,7 @@ const structuredData = {
 
 <BaseLayout hideBrandTag={true} title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div>
     <div {...inlineObjectId('content/pages/contact.json')}>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -5,9 +5,63 @@ import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 
 const pageDoc: any = await loadPageDoc('faq');
+
+const faqStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Will modifications void my factory warranty?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text:
+          'Performance modifications can void all or part of your vehicle’s OEM warranty. Check with your dealership or warranty provider before any upgrades.'
+      }
+    },
+    {
+      '@type': 'Question',
+      name: 'Do you offer custom tuning for boosted platforms?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text:
+          'Yes, we specialize in tuning for supercharged and turbocharged applications across a range of domestic performance vehicles.'
+      }
+    },
+    {
+      '@type': 'Question',
+      name: 'What kind of horsepower gains can I expect?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text:
+          'Gains depend on platform and mods. Typical builds range from 600 WHP to 1500+ WHP. We’ll recommend options based on your goals.'
+      }
+    },
+    {
+      '@type': 'Question',
+      name: 'Do you offer installation or is it DIY only?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text:
+          'We provide professional installation in‑house. You can also purchase parts for local install if preferred.'
+      }
+    },
+    {
+      '@type': 'Question',
+      name: 'Do you offer warranties on performance parts?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Aftermarket parts are sold as‑is and may reduce component life depending on use.'
+      }
+    }
+  ]
+};
 ---
 
 <BaseLayout>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={JSON.stringify(faqStructuredData)} />
+  </Fragment>
     <div {...inlineObjectId('content/pages/faq.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>{pageDoc?.title ?? 'Frequently Asked Questions'}</div>
     {Array.isArray(pageDoc?.sections) && pageDoc.sections.length > 0 && (
@@ -99,38 +153,3 @@ const pageDoc: any = await loadPageDoc('faq');
     </section>
     </div>
 </BaseLayout>
-
-<!-- FAQ Page JSON-LD -->
-<script type="application/ld+json">
-{JSON.stringify({
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: [
-    {
-      '@type': 'Question',
-      name: 'Will modifications void my factory warranty?',
-      acceptedAnswer: { '@type': 'Answer', text: 'Performance modifications can void all or part of your vehicle’s OEM warranty. Check with your dealership or warranty provider before any upgrades.' }
-    },
-    {
-      '@type': 'Question',
-      name: 'Do you offer custom tuning for boosted platforms?',
-      acceptedAnswer: { '@type': 'Answer', text: 'Yes, we specialize in tuning for supercharged and turbocharged applications across a range of domestic performance vehicles.' }
-    },
-    {
-      '@type': 'Question',
-      name: 'What kind of horsepower gains can I expect?',
-      acceptedAnswer: { '@type': 'Answer', text: 'Gains depend on platform and mods. Typical builds range from 600 WHP to 1500+ WHP. We’ll recommend options based on your goals.' }
-    },
-    {
-      '@type': 'Question',
-      name: 'Do you offer installation or is it DIY only?',
-      acceptedAnswer: { '@type': 'Answer', text: 'We provide professional installation in‑house. You can also purchase parts for local install if preferred.' }
-    },
-    {
-      '@type': 'Question',
-      name: 'Do you offer warranties on performance parts?',
-      acceptedAnswer: { '@type': 'Answer', text: 'Aftermarket parts are sold as‑is and may reduce component life depending on use.' }
-    }
-  ]
-})}
-</script>

--- a/src/pages/jtx/wheels.astro
+++ b/src/pages/jtx/wheels.astro
@@ -37,9 +37,7 @@ const breadcrumbStructuredData = {
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(breadcrumbStructuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
   </Fragment>
   <JtxHero title="JTX Forged — Custom Spec Quote" subtitle="ARC Monoforged truck wheels with premium finishes and popular 5/6/8 lug patterns." />
   <div class="mx-auto max-w-7xl px-6 py-6">

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -37,9 +37,7 @@ const structuredData = {
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/schedule.json')} class="bg-[#121212]">
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>{pageDoc?.title ?? 'Schedule'}</div>

--- a/src/pages/shop/index.astro
+++ b/src/pages/shop/index.astro
@@ -244,9 +244,7 @@ if (endPage < totalPages) {
 
 <BaseLayout title={metaTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(breadcrumbStructuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
   </Fragment>
   <section class="max-w-full px-2 md:px-2 mt-11 pt-10">
     <div class="mb-6 mt-2 space-y-3">

--- a/src/pages/shop/storefront.astro
+++ b/src/pages/shop/storefront.astro
@@ -54,9 +54,7 @@ const breadcrumbStructuredData = {
 
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json">
-      {JSON.stringify(breadcrumbStructuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
   </Fragment>
 
 <section class="px-5 py-5">

--- a/src/pages/specs/BilletBearingPlate.astro
+++ b/src/pages/specs/BilletBearingPlate.astro
@@ -63,9 +63,7 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletBearingPlateSpecs.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/BilletLid.astro
+++ b/src/pages/specs/BilletLid.astro
@@ -65,9 +65,7 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletLidSpecsSheet.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/BilletSnout.astro
+++ b/src/pages/specs/BilletSnout.astro
@@ -98,9 +98,7 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={primaryImage}>
   <Fragment slot="head">
     <meta property="og:type" content="product.group" />
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletSnoutSpecs.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/BilletThrottleBody108.astro
+++ b/src/pages/specs/BilletThrottleBody108.astro
@@ -64,9 +64,7 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletThrottleBody108Specs.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/PredatorPulley.astro
+++ b/src/pages/specs/PredatorPulley.astro
@@ -62,9 +62,7 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/specs/PredatorPulley.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/PulleyHub.astro
+++ b/src/pages/specs/PulleyHub.astro
@@ -69,9 +69,7 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json">
-      {JSON.stringify(structuredData)}
-    </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
   <div {...inlineObjectId('content/pages/HellcatPulleyHubSpecSheet.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>


### PR DESCRIPTION
## Summary
- render JSON-LD structured data with `set:html` across policy, shop, and spec pages so Google can parse the markup
- move the FAQ structured data definition into frontmatter and emit it through the layout head slot

## Testing
- yarn lint
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68f6a0a2eab4832c884f300d612e4e49