### PR TITLE
Fix Merchant Center desktop availability issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This project now includes a helper script that exports current products from San
    - **Content API (recommended):** set `GMC_CONTENT_API_MERCHANT_ID` and supply a service account credential via `GMC_SERVICE_ACCOUNT_KEY` (JSON string), `GMC_SERVICE_ACCOUNT_KEY_BASE64`, or `GMC_SERVICE_ACCOUNT_KEY_FILE`. Store the JSON in your secret manager and inject it at runtime; avoid committing the file.
    - **SFTP fallback:** keep `GMC_SFTP_HOST`, `GMC_SFTP_PORT`, `GMC_SFTP_USERNAME`, `GMC_SFTP_PASSWORD`, and `GMC_SFTP_FEED_FILENAME` if you still need file-based uploads.
    - Optional defaults: `GMC_FEED_BASE_URL`, `GMC_FEED_CURRENCY`, `GMC_FEED_LANGUAGE`, `GMC_FEED_TARGET_COUNTRY`, `GMC_FEED_DEFAULT_WEIGHT_LB`, `GMC_FEED_DEFAULT_QUANTITY`, and `GMC_FEED_SHIPPING_PRICE`.
+   - Opt-in behaviour: set `GMC_FEED_ENABLE_ADS_REDIRECT=true` only if you explicitly want Merchant Center to use the `/checkout/quick/<slug>` landing pages for ads. It defaults to `false` so product ads lead to the full product detail page on all devices.
 2. Install dependencies if you haven’t already: `yarn install`.
 3. Generate and upload the feed: `yarn merchant:upload`.
 

--- a/scripts/merchant/upload-google-merchant-feed.ts
+++ b/scripts/merchant/upload-google-merchant-feed.ts
@@ -61,6 +61,17 @@ const DEFAULT_GOOGLE_PRODUCT_CATEGORY =
   process.env.GMC_FEED_DEFAULT_GOOGLE_CATEGORY ||
   'Vehicles & Parts > Vehicle Parts & Accessories > Performance Parts';
 
+function parseBooleanEnv(value: string | undefined, defaultValue = false): boolean {
+  if (typeof value !== 'string') return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return defaultValue;
+}
+
+const ENABLE_ADS_REDIRECT = parseBooleanEnv(process.env.GMC_FEED_ENABLE_ADS_REDIRECT, false);
+
 const REQUIRED_COLUMNS: (keyof MerchantRow)[] = [
   'id',
   'title',
@@ -400,7 +411,7 @@ function buildRows(products: any[], baseUrl: string, currency: string): Merchant
         shipping_weight: `${computeWeight(product?.shippingWeight).toFixed(2)} lb`
       };
 
-      if (quickCheckoutUrl) {
+      if (ENABLE_ADS_REDIRECT && quickCheckoutUrl) {
         row.ads_redirect = quickCheckoutUrl;
       }
 

--- a/src/pages/checkout/quick/[slug].ts
+++ b/src/pages/checkout/quick/[slug].ts
@@ -110,3 +110,17 @@ export const GET: APIRoute = async ({ params, request }) => {
   console.error('[quick-checkout] Checkout API error:', response.status, rawBody);
   return Response.redirect(productUrl, 303);
 };
+
+export const HEAD: APIRoute = async ({ params, request }) => {
+  const slugParam = params.slug ? normalizeSlug(params.slug) : '';
+  if (!slugParam) {
+    return new Response(null, { status: 400 });
+  }
+
+  const requestUrl = new URL(request.url);
+  const origin = requestUrl.origin;
+  const productUrl = new URL(`/shop/${slugParam}`, origin);
+  const headers = new Headers({ Location: productUrl.toString() });
+
+  return new Response(null, { status: 302, headers });
+};


### PR DESCRIPTION
## Summary
- gate Google Merchant Center `ads_redirect` generation behind an explicit opt-in flag so discovery ads land on the full product page by default
- add a HEAD handler for the quick checkout endpoint so desktop probes receive a redirect instead of 405 errors
- document the new `GMC_FEED_ENABLE_ADS_REDIRECT` toggle in the Merchant Center setup instructions

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68f6a25bdc2c832c9f49d8b0a5ceaaec