### PR TITLE
Patch: sanitize about page JSON-LD injection

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -37,10 +37,14 @@ const structuredData = {
     'https://www.instagram.com/fasmotorsports'
   ]
 };
+const sanitizedStructuredData = JSON.stringify(structuredData)
+  .replace(/</g, '\\u003c')
+  .replace(/>/g, '\\u003e')
+  .replace(/&/g, '\\u0026');
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script type="application/ld+json" set:html={sanitizedStructuredData} />
   </Fragment>
   <div {...inlineObjectId('content/pages/about.json')}>
     <!-- Inline-editable Page Title (mapped to content/pages/about.json:title) -->


### PR DESCRIPTION
## Summary
- sanitize the about page JSON-LD string before injecting it with `set:html`

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68f7e3ac7e0c832c8b8e0683e43c2e9d