### PR TITLE
Fix JSON-LD sanitization when injecting script tags

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,3 +2,10 @@
 export function cn(...classes: (string | undefined | null | false)[]) {
   return classes.filter(Boolean).join(' ');
 }
+
+export function serializeJsonLd(data: unknown) {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,6 +3,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 
 import AboutHero from '@/components/hero/AboutHero.astro';
 import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
+import { serializeJsonLd } from '@lib/utils';
 
 
 
@@ -37,10 +38,7 @@ const structuredData = {
     'https://www.instagram.com/fasmotorsports'
   ]
 };
-const sanitizedStructuredData = JSON.stringify(structuredData)
-  .replace(/</g, '\\u003c')
-  .replace(/>/g, '\\u003e')
-  .replace(/&/g, '\\u0026');
+const sanitizedStructuredData = serializeJsonLd(structuredData);
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">

--- a/src/pages/belak/wheels.astro
+++ b/src/pages/belak/wheels.astro
@@ -4,6 +4,7 @@ import BelakHero from "@/components/belak/BelakHero.astro";
 import BelakSidebar from "@/components/belak/BelakSidebar.astro";
 import WheelSpecForm from "@/components/belak/WheelSpecForm";
 import WheelsHero from '@/components/WheelsHero';
+import { serializeJsonLd } from '@lib/utils';
 
 const requestUrl = new URL(Astro.request.url);
 requestUrl.search = '';
@@ -35,7 +36,10 @@ const breadcrumbStructuredData = {
 
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(breadcrumbStructuredData)}
+    />
   </Fragment>
 
  <BelakHero

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const pageDoc: any = await loadPageDoc('contact');
 const requestUrl = new URL(Astro.request.url);
@@ -39,7 +40,10 @@ const structuredData = {
 
 <BaseLayout hideBrandTag={true} title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div>
     <div {...inlineObjectId('content/pages/contact.json')}>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Button from '../components/Button.astro';
 import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const pageDoc: any = await loadPageDoc('faq');
 
@@ -60,7 +61,10 @@ const faqStructuredData = {
 
 <BaseLayout>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(faqStructuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(faqStructuredData)}
+    />
   </Fragment>
     <div {...inlineObjectId('content/pages/faq.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>{pageDoc?.title ?? 'Frequently Asked Questions'}</div>

--- a/src/pages/jtx/wheels.astro
+++ b/src/pages/jtx/wheels.astro
@@ -4,6 +4,7 @@ import JtxHero from '@/components/jtx/JtxHero.astro';
 import JtxSidebar from '@/components/jtx/JtxSidebar.astro';
 import JtxWheelSpecForm from '@/components/jtx/JtxWheelSpecForm';
 import { JTX_SERIES } from '@/content/jtx/options';
+import { serializeJsonLd } from '@lib/utils';
 
 // Read ?series=... and validate against known series
 const url = new URL(Astro.request.url);
@@ -37,7 +38,10 @@ const breadcrumbStructuredData = {
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(breadcrumbStructuredData)}
+    />
   </Fragment>
   <JtxHero title="JTX Forged — Custom Spec Quote" subtitle="ARC Monoforged truck wheels with premium finishes and popular 5/6/8 lug patterns." />
   <div class="mx-auto max-w-7xl px-6 py-6">

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -5,6 +5,7 @@ import SectionRenderer from '@/components/SectionRenderer.astro';
 const pageDoc: any = await loadPageDoc('schedule');
 import BookingForm from '../components/BookingForm';
 import AppointmentCard from '../components/appointmentCard.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const response = await fetch('https://api.cal.com/v1/bookings', {
   headers: { Authorization: `Bearer ${import.meta.env.PUBLIC_CALCOM_API_KEY}` }
@@ -37,7 +38,10 @@ const structuredData = {
 ---
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/schedule.json')} class="bg-[#121212]">
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>{pageDoc?.title ?? 'Schedule'}</div>

--- a/src/pages/shop/[slug].astro
+++ b/src/pages/shop/[slug].astro
@@ -5,6 +5,7 @@ import PortableTextRenderer from "../../components/PortableTextRenderer.jsx";
 import SlugCarousel from '@/components/SlugCarousel.astro';
 import TrustStrip from '@/components/TrustStrip.astro';
 import { inlineFieldAttrs, inlineObjectId } from '@lib/content';
+import { serializeJsonLd } from '@lib/utils';
 
 export type KitItem = { item: string; quantity?: number };
 export type VehicleCompat = { make?: string; model?: string; trim?: string };
@@ -482,10 +483,16 @@ if (!productNotFound) {
     <meta property="product:availability" content="https://schema.org/InStock" />
     {metaKeywords && <meta name="keywords" content={metaKeywords} />}
     {breadcrumbStructuredData && (
-      <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
+      <script
+        type="application/ld+json"
+        set:html={serializeJsonLd(breadcrumbStructuredData)}
+      />
     )}
     {productStructuredData && (
-      <script type="application/ld+json" set:html={JSON.stringify(productStructuredData)} />
+      <script
+        type="application/ld+json"
+        set:html={serializeJsonLd(productStructuredData)}
+      />
     )}
   </Fragment>
   <div {...inlineObjectId((product as any)._id)}>
@@ -1040,7 +1047,10 @@ if (!productNotFound) {
   <BaseLayout title={seoTitle} description={seoDesc} canonical={seoCanon} noindex>
     {breadcrumbStructuredData && (
       <Fragment slot="head">
-        <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
+        <script
+          type="application/ld+json"
+          set:html={serializeJsonLd(breadcrumbStructuredData)}
+        />
       </Fragment>
     )}
     <section class="mx-auto flex min-h-[60vh] max-w-3xl flex-col items-center justify-center px-4 py-24 text-center text-white">

--- a/src/pages/shop/index.astro
+++ b/src/pages/shop/index.astro
@@ -4,6 +4,7 @@ import ShopTopControls from '@components/shop/ShopTopControls';
 import ShopSidebarFilters from '@/components/storefront/ShopSidebarFilters';
 import { fetchProductsFromSanity, fetchCategories } from '@lib/sanity-utils';
 import type { Product, Category } from '@lib/sanity-utils';
+import { serializeJsonLd } from '@lib/utils';
 import ProductGrid from '@/components/storefront/ProductGrid.astro';
 import FilterPanelMobile from '@/components/storefront/FilterPanelMobile.tsx';
 import Pagination from '@/components/storefront/Pagination.astro';
@@ -244,7 +245,10 @@ if (endPage < totalPages) {
 
 <BaseLayout title={metaTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(breadcrumbStructuredData)}
+    />
   </Fragment>
   <section class="max-w-full px-2 md:px-2 mt-11 pt-10">
     <div class="mb-6 mt-2 space-y-3">

--- a/src/pages/shop/storefront.astro
+++ b/src/pages/shop/storefront.astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import CategoryPage from "@/components/storefront/CategoryPage.tsx";
 import { fetchProductsFromSanity } from "@/lib/sanity-utils";
 import { sanityClient as client } from "@/lib/sanityClient";
+import { serializeJsonLd } from '@lib/utils';
 
 const products = await fetchProductsFromSanity({});
 
@@ -54,7 +55,10 @@ const breadcrumbStructuredData = {
 
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical}>
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbStructuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(breadcrumbStructuredData)}
+    />
   </Fragment>
 
 <section class="px-5 py-5">

--- a/src/pages/specs/BilletBearingPlate.astro
+++ b/src/pages/specs/BilletBearingPlate.astro
@@ -4,6 +4,7 @@ import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 const pageDoc: any = await loadPageDoc('BilletBearingPlateSpecs');
 import ProductSpecSheet from '@components/specs/ProductSpecSheet.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const pageTitle: string = pageDoc?.title ?? 'Billet Bearing Plate — Spec Sheet';
 const pageDescription =
@@ -63,7 +64,10 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletBearingPlateSpecs.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/BilletLid.astro
+++ b/src/pages/specs/BilletLid.astro
@@ -3,6 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 import ProductSpecSheet from '@components/specs/ProductSpecSheet.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 // Backed by content/pages/BilletLidSpecsSheet.json
 const pageDoc: any = await loadPageDoc('BilletLidSpecsSheet');
@@ -65,7 +66,10 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletLidSpecsSheet.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/BilletSnout.astro
+++ b/src/pages/specs/BilletSnout.astro
@@ -3,6 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 import ProductSpecSheet from '@components/specs/ProductSpecSheet.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const pageDoc: any = await loadPageDoc('BilletSnoutSpecs');
 
@@ -98,7 +99,10 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={primaryImage}>
   <Fragment slot="head">
     <meta property="og:type" content="product.group" />
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletSnoutSpecs.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/BilletThrottleBody108.astro
+++ b/src/pages/specs/BilletThrottleBody108.astro
@@ -3,6 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 import ProductSpecSheet from '@components/specs/ProductSpecSheet.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 // Backed by content/pages/BilletThrottleBody108Specs.json
 const pageDoc: any = await loadPageDoc('BilletThrottleBody108Specs');
@@ -64,7 +65,10 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/BilletThrottleBody108Specs.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/PredatorPulley.astro
+++ b/src/pages/specs/PredatorPulley.astro
@@ -4,6 +4,7 @@ import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 const pageDoc: any = await loadPageDoc('PredatorPulleySpecsSheet');
 import ProductSpecSheet from '@components/specs/ProductSpecSheet.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const pageTitle: string = pageDoc?.title ?? 'Predator Pulley — Spec Sheet';
 const pageDescription =
@@ -62,7 +63,10 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/specs/PredatorPulley.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>

--- a/src/pages/specs/PulleyHub.astro
+++ b/src/pages/specs/PulleyHub.astro
@@ -4,6 +4,7 @@ import { loadPageDoc, inlineFieldAttrs, inlineObjectId } from '@lib/content';
 import SectionRenderer from '@/components/SectionRenderer.astro';
 const pageDoc: any = await loadPageDoc('HellcatPulleyHubSpecSheet');
 import ProductSpecSheet from '@components/specs/ProductSpecSheet.astro';
+import { serializeJsonLd } from '@lib/utils';
 
 const pageTitle: string = pageDoc?.title ?? 'Pulley & Hub Kit — Spec Sheet';
 const pageDescription =
@@ -69,7 +70,10 @@ const structuredData = {
 <BaseLayout title={pageTitle} description={pageDescription} canonical={canonical} ogImage={ensureAbsolute(specSheet.imageSrc)}>
   <Fragment slot="head">
     <meta property="og:type" content="product" />
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(structuredData)}
+    />
   </Fragment>
   <div {...inlineObjectId('content/pages/HellcatPulleyHubSpecSheet.json')}>
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>


### PR DESCRIPTION
## Summary
- add a shared JSON-LD serializer that escapes characters which could prematurely terminate script tags
- use the sanitized serializer across pages that inject structured data from CMS content

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68f7e82a419c832caeb9d86f4b308bfa