### PR TITLE
Remove Shop Now button from IGLA service page

### DIFF
--- a/src/pages/services/igla.astro
+++ b/src/pages/services/igla.astro
@@ -108,7 +108,6 @@ const ogImageAbsolute = new URL('/logo/faslogochroma.png', requestUrl.origin).to
       <div id="carousel" class="space-y-6 transition-opacity duration-500">
         <h1 id="carousel-title" class="text-4xl font-cyber text-primary">IGLA FEATURE</h1>
         <h2 id="carousel-subtitle" class="text-xl font-ethno text-white">Smart Anti-Theft with Full System Control</h2>
-        <Button href="/shop" text="Shop Now" variant="default" />
       </div>
     </div>
 

--- a/src/pages/services/igla.astro
+++ b/src/pages/services/igla.astro
@@ -76,7 +76,7 @@ const ogImageAbsolute = new URL('/logo/faslogochroma.png', requestUrl.origin).to
       </div>
     </section>
 
-  <section class="luxury-particles relative text-white pt-20 pb-32 px-6 ">
+  <section class="luxury-particles relative text-white pt-20 pb-32 px-6">
     <div class="absolute inset-0"></div>
     <div class="relative z-10 max-w-6xl mx-auto">
       <h1 class="text-4xl font-cyber font-bold text-primary mb-6">Ready to protect what moves you? </h1>
@@ -181,7 +181,7 @@ const ogImageAbsolute = new URL('/logo/faslogochroma.png', requestUrl.origin).to
       <div class="h-[2px] w-20 bg-[#1d92ea] my-2"></div>
       <h2 class="text-white font-mono tracking-[1.2px] text-lg mb-6">The IGLA system integrates directly with your vehicle’s digital architecture</h2>
       <p class="text-white leading-relaxed text-xs font-mono">
-        Using CAN and LIN bus protocols — to silently block unauthorized access. It doesn’t rely on visible hardware or LEDs, making it undetectable to thieves. Whether it’s key cloning, relay attacks, or ECU swapping, IGLA shuts down the engine or transmission preemptively, all controlled via a customizable PIN, mobile app, or factory buttons.      </p>
+        Using CAN and LIN bus protocols — to silently block unauthorized access. It doesn’t rely on visible hardware or LEDs, making it undetectable to thieves. Whether it’s key cloning, relay attacks, or ECU swapping, IGLA shuts down the engine or transmission preemptively, all controlled via a customizable PIN, mobile app, or factory buttons.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary
- remove the Shop Now button from the IGLA service page carousel to avoid product-style CTA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f81ca3ee40832c9b9c7ccce96eeb8a