### PR TITLE
Default to UPS shipping rates - allow USPS carriers when flag enabled

### DIFF
--- a/src/server/shipping/quote.ts
+++ b/src/server/shipping/quote.ts
@@ -335,6 +335,7 @@ const listCarrierIds = async (): Promise<string[]> => {
     if (Array.isArray(carriers)) {
       return carriers
         .filter((carrier: any) => {
+          if (ALLOW_USPS) return true;
           const code = String(carrier?.carrier_code || carrier?.carrierCode || '').toLowerCase();
           const name = String(carrier?.friendly_name || carrier?.friendlyName || '').toLowerCase();
           return !code.includes('usps') && !name.includes('usps');
@@ -360,9 +361,10 @@ const resolveCarrierIds = async (): Promise<string[]> => {
     .map((value) => value.trim())
     .filter((value) => looksLikeCarrierId(value));
 
-  const explicit = dedupe([...envCarrierIds, ...singleCarrierIds]).filter(
-    (value) => !value.toLowerCase().includes('usps')
-  );
+  const explicit = dedupe([...envCarrierIds, ...singleCarrierIds]).filter((value) => {
+    if (ALLOW_USPS) return true;
+    return !value.toLowerCase().includes('usps');
+  });
   if (explicit.length) return explicit;
 
   if (cachedCarrierIds) return cachedCarrierIds;


### PR DESCRIPTION
## Summary
- allow ShipEngine carrier discovery to keep USPS carrier IDs when the ALLOW_USPS flag is enabled so USPS quotes can be returned

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68f935785460832cad4183d5cda89298