### PR TITLE
Filter out Global Post shipping rates

### DIFF
--- a/src/server/shipping/quote.ts
+++ b/src/server/shipping/quote.ts
@@ -614,8 +614,10 @@ export async function computeShippingQuote(
         const serviceLabel = `${rate.service || ''} ${rate.serviceName || ''}`.toLowerCase();
         const isMediaMail =
           serviceCode.includes('media_mail') || serviceLabel.includes('media mail');
+        const isGlobalPost =
+          serviceCode.includes('globalpost') || serviceLabel.includes('global post');
 
-        if (isMediaMail) return false;
+        if (isMediaMail || isGlobalPost) return false;
 
         if (!ALLOW_USPS && isUspsRate(rate)) return false;
 


### PR DESCRIPTION
## Summary
- update the shipping rate filtering logic to drop any Global Post services so they no longer appear at checkout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fba80c9078832cbdbeded6b548f3da