### PR TITLE
Handle missing Sanity overlays and guard GA setup

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -226,6 +226,13 @@ const breadcrumbItems = shouldRenderBreadcrumbs
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17641771829"></script>
     <script is:inline>
+      if (typeof window !== 'undefined') {
+        window.inlineGaSetup ??= function inlineGaSetup() {
+          return undefined;
+        };
+      }
+    </script>
+    <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){window.dataLayer.push(arguments);}
       window.gtag = gtag;


### PR DESCRIPTION
## Summary
- add a defensive inline definition for `inlineGaSetup` so the Google Analytics snippet no longer throws before it loads
- lazily import `@sanity/overlays` and fall back gracefully when it is unavailable, keeping visual editing optional without breaking builds

## Testing
- node_modules/.bin/astro build

------
https://chatgpt.com/codex/tasks/task_e_68fbd8c17988832c819762b6964478a8