### PR TITLE
Fix Sanity overlays dynamic import resolution

### DIFF
--- a/src/components/sanity/VisualEditingBridge.tsx
+++ b/src/components/sanity/VisualEditingBridge.tsx
@@ -63,8 +63,7 @@ type OverlaysModule = {
 
 const loadOverlays = async (): Promise<OverlaysModule | null> => {
   try {
-    const specifier = '@sanity/overlays'
-    const mod = (await import(/* @vite-ignore */ specifier)) as OverlaysModule
+    const mod = (await import('@sanity/overlays')) as OverlaysModule
     return mod
   } catch (err) {
     console.warn('[sanity] Failed to load @sanity/overlays:', err)


### PR DESCRIPTION
## Summary
- ensure the dynamic import for `@sanity/overlays` uses a bundler-resolvable specifier so optional overlays can load when present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbddc88c80832c99777eb79dce9388