### PR TITLE
Ensure Sanity visual editing honors query toggles

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -100,6 +100,18 @@ const previewDraftsEnabled =
     (import.meta.env.PUBLIC_SANITY_PREVIEW_DRAFTS as string | undefined) ?? 'true'
   );
 
+if (import.meta.env.SSR) {
+  (globalThis as { __SANITY_VISUAL_EDITING_OVERRIDE__?: boolean }).__SANITY_VISUAL_EDITING_OVERRIDE__ =
+    visualEditingEnabled;
+  (globalThis as { __SANITY_VISUAL_EDITING_URL__?: string | undefined }).__SANITY_VISUAL_EDITING_URL__ =
+    currentUrl?.toString();
+}
+
+const syncVisualEditingStateScript = `
+  window.__SANITY_VISUAL_EDITING_OVERRIDE__ = ${JSON.stringify(visualEditingEnabled)};
+  window.__SANITY_VISUAL_EDITING_URL__ = ${JSON.stringify(currentUrl?.toString() ?? null)};
+`;
+
 const resolvedStudioUrl =
   (import.meta.env.PUBLIC_SANITY_STUDIO_URL as string | undefined) ||
   (import.meta.env.PUBLIC_STUDIO_URL as string | undefined) ||
@@ -240,6 +252,7 @@ const breadcrumbItems = shouldRenderBreadcrumbs
         /* noop */
       }
     </script>
+    <script is:inline set:html={syncVisualEditingStateScript}></script>
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico" />


### PR DESCRIPTION
## Summary
- honor query-based overrides when enabling Sanity visual editing, preview drafts, and stega support
- expose the current request URL and toggle state to the Sanity utilities from the base layout so client and overlays stay in sync

## Testing
- yarn lint --format stylish *(fails: Type Error: Cannot destructure property 'version' of 's[a]' as it is null.)*

------
https://chatgpt.com/codex/tasks/task_e_68fbe31099d8832c95644362b564ba20