### PR TITLE
Handle missing Sanity overlays and guard GA setup follow-up

### DIFF
--- a/src/components/sanity/VisualEditingBridge.tsx
+++ b/src/components/sanity/VisualEditingBridge.tsx
@@ -63,6 +63,7 @@ type OverlaysModule = {
 
 const loadOverlays = async (): Promise<OverlaysModule | null> => {
   try {
+    // Keep the bare specifier literal so Vite rewrites it into a browser-resolvable chunk.
     const mod = (await import('@sanity/overlays')) as OverlaysModule
     return mod
   } catch (err) {


### PR DESCRIPTION
## Summary
- document that the `@sanity/overlays` dynamic import must remain a bare specifier so Vite rewrites it for the browser

## Testing
- not run (comment-only clarification)

------
https://chatgpt.com/codex/tasks/task_e_68fbe2f9d0f8832c8c71334d67dbef68