### PR TITLE
Fix Netlify fallback redirect to restore asset delivery

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,10 +13,12 @@
   to = "/shop/categories/:splat"
   status = 301
 
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+# Astro already generates the correct serverless function routing for SSR builds.
+# A blanket SPA-style catch-all would rewrite asset requests (e.g. CSS, JS, Astro
+# component modules) to the HTML shell which then surfaces in the browser as
+# "Failed to load module script" MIME-type errors. Removing the fallback keeps
+# the platform-provided routing intact while still allowing the upstream
+# redirect table above to function as intended.
 
 ## Note: Custom auth uses Astro API under /api/auth/*; no redirects needed.
 


### PR DESCRIPTION
## Summary
- remove the SPA-style catch-all redirect in `netlify.toml`
- document why Astro's SSR routing should handle requests so module assets resolve with correct MIME types

## Testing
- not run (Yarn install currently fails locally with `TypeError: Cannot destructure property 'version' of 's[a]' as it is null.`)


------
https://chatgpt.com/codex/tasks/task_e_68fbe50ebd58832c998c34388b3f83f1