### PR TITLE
Update site contact email to sales@fasmotorsports.com

### DIFF
--- a/netlify/functions/stripe-webhook.ts
+++ b/netlify/functions/stripe-webhook.ts
@@ -802,7 +802,7 @@ export const handler: Handler = async (event) => {
                   ${shippingBlock}
                   ${paymentMethod}
                   <div style="margin-top:24px;padding-top:16px;border-top:1px solid #e5e7eb;color:#6b7280;font-size:13px;line-height:1.6;">
-                    <p style="margin:0 0 8px 0;">If you have any questions, reply to this email or contact us at <a href="mailto:support@fasmotorsports.com" style="color:#ef4444;text-decoration:none;">support@fasmotorsports.com</a>.</p>
+                    <p style="margin:0 0 8px 0;">If you have any questions, reply to this email or contact us at <a href="mailto:sales@fasmotorsports.com" style="color:#ef4444;text-decoration:none;">sales@fasmotorsports.com</a>.</p>
                     <p style="margin:0;">Thank you for choosing FAS Motorsports.</p>
                   </div>
                 </div>

--- a/netlify/functions/submission-created.ts
+++ b/netlify/functions/submission-created.ts
@@ -10,7 +10,7 @@ export const handler: Handler = async (event) => {
     const formName: string = payload?.form_name || payload?.formName || 'unknown-form';
     const data: Record<string, any> = payload?.data || payload || {};
 
-    const to = process.env.NOTIFY_EMAIL || 'support@fasmotorsports.com';
+    const to = process.env.NOTIFY_EMAIL || 'sales@fasmotorsports.com';
     const from = process.env.NOTIFY_FROM || 'no-reply@fasmotorsports.com';
 
     const subject = `New ${formName} submission`;

--- a/src/components/accountdashboard.astro
+++ b/src/components/accountdashboard.astro
@@ -33,7 +33,7 @@
     <div class="mt-6 border-t border-gray-800 pt-3 text-[0.95rem] font-mono">
       <p class="mb-1 text-white/70 text-xs uppercase tracking-wide">Need help?</p>
       <div class="flex items-center space-x-2 mb-1 leading-tight">
-        <span class="text-[11px] font-mono text-white/70 break-all">support@fasmotorsports.com</span>
+        <span class="text-[11px] font-mono text-white/70 break-all">sales@fasmotorsports.com</span>
       </div>
       <div class="flex items-center space-x-2 leading-tight">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-white/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -54,11 +54,11 @@ const socialLinks = [
           </svg>
           +1 (812) 200-9012
         </a>
-        <a href="mailto:support@fasmotorsports.com" class="flex items-center justify-center gap-2 hover:text-white transition-colors">
+        <a href="mailto:sales@fasmotorsports.com" class="flex items-center justify-center gap-2 hover:text-white transition-colors">
           <svg class="h-3.5 w-3.5 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M4 4h16v16H4z"/><path d="m22 6-10 7L2 6"/>
           </svg>
-          support@fasmotorsports.com
+          sales@fasmotorsports.com
         </a>
       </div>
 

--- a/src/pages/api/webhooks.ts
+++ b/src/pages/api/webhooks.ts
@@ -637,7 +637,7 @@ export async function POST({ request }: { request: Request }) {
                 ${shippingBlock}
                 ${paymentMethod}
                 <div style="margin-top:24px;padding-top:16px;border-top:1px solid #e5e7eb;color:#6b7280;font-size:13px;line-height:1.6;">
-                  <p style="margin:0 0 8px 0;">If you have any questions, reply to this email or contact us at <a href="mailto:support@fasmotorsports.com" style="color:#ef4444;text-decoration:none;">support@fasmotorsports.com</a>.</p>
+                  <p style="margin:0 0 8px 0;">If you have any questions, reply to this email or contact us at <a href="mailto:sales@fasmotorsports.com" style="color:#ef4444;text-decoration:none;">sales@fasmotorsports.com</a>.</p>
                   <p style="margin:0;">Thank you for choosing FAS Motorsports.</p>
                 </div>
               </div>
@@ -697,7 +697,7 @@ export async function POST({ request }: { request: Request }) {
           },
           body: JSON.stringify({
             from: RESEND_FROM,
-            to: ['support@fasmotorsports.com', 'info@fasmotorsports.com'],
+            to: ['sales@fasmotorsports.com', 'info@fasmotorsports.com'],
             subject: `New Order: ${orderNumber}`,
             html: internalHtml
           })

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -18,7 +18,7 @@ const structuredData = {
   name: 'F.A.S. Motorsports',
   url: canonical,
   telephone: '(812) 200-9012',
-  email: 'support@fasmotorsports.com',
+  email: 'sales@fasmotorsports.com',
   address: {
     '@type': 'PostalAddress',
     streetAddress: '6161 Riverside Dr',
@@ -117,7 +117,7 @@ const structuredData = {
             <p class="mb-4 text-white/60"><strong class="text-primary">Phone:</strong> (812) 200-9012</p>
             <p class="mb-4 text-white/60">
               <strong class="text-primary">Email:</strong>
-              <a href="mailto:support@fasmotorsports.com" class="text-accent hover:text-primary">support@fasmotorsports.com</a>
+              <a href="mailto:sales@fasmotorsports.com" class="text-accent hover:text-primary">sales@fasmotorsports.com</a>
             </p>
             <p class="mb-4 text-white/60">
               <strong class="text-primary">Sales:</strong>

--- a/src/pages/returnRefundPolicy.astro
+++ b/src/pages/returnRefundPolicy.astro
@@ -58,11 +58,11 @@ const canonicalUrl = `${new URL(Astro.request.url).origin}/returnRefundPolicy`;
       Next contact your bank. There is often some processing time before a refund is posted.
     </p>
 
-    <p class='mb-4 font-bold font-sans'>If you’ve done all of this and you still have not received your refund yet, please contact us at <a href="mailto:support@fasmotorsports.com" class="text-accent hover:text-white">support@fasmotorsports.com</a> immediately.</p>
+    <p class='mb-4 font-bold font-sans'>If you’ve done all of this and you still have not received your refund yet, please contact us at <a href="mailto:sales@fasmotorsports.com" class="text-accent hover:text-white">sales@fasmotorsports.com</a> immediately.</p>
 
     <h2 class="text-2xl font-cyber text-primary mt-10 mb-2">Exchanges</h2>
     <p class="mb-4">
-      We only replace items if they are defective or damaged. If you need to exchange it for the same item, send us an email at <a href="mailto:support@fasmotorsports.com" class="text-accent hover:text-white">support@fasmotorsports.com</a> and send your item to <a href="https://www.google.com/maps/dir/?api=1&destination=6161+Riverside+Dr,+Punta+Gorda,+FL+33982" target="_blank" rel="noopener noreferrer"  class="text-accent hover:text-white">
+      We only replace items if they are defective or damaged. If you need to exchange it for the same item, send us an email at <a href="mailto:sales@fasmotorsports.com" class="text-accent hover:text-white">sales@fasmotorsports.com</a> and send your item to <a href="https://www.google.com/maps/dir/?api=1&destination=6161+Riverside+Dr,+Punta+Gorda,+FL+33982" target="_blank" rel="noopener noreferrer"  class="text-accent hover:text-white">
         6161 Riverside Dr. Punta Gorda, FL 33982</a>
     </p>
 
@@ -82,7 +82,7 @@ const canonicalUrl = `${new URL(Astro.request.url).origin}/returnRefundPolicy`;
     </p>
     <p class="mb-4">
       If you have any questions, please contact us at
-      <a href="mailto:support@fasmotorsports.com" class="text-accent hover:text-white">support@fasmotorsports.com</a>.
+      <a href="mailto:sales@fasmotorsports.com" class="text-accent hover:text-white">sales@fasmotorsports.com</a>.
     </p>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- point Netlify submission handler and API webhook notifications to sales@fasmotorsports.com
- replace support@fasmotorsports.com with sales@fasmotorsports.com across customer-facing content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc0a349bac832ca3c2b8f2eb547d32