### PR TITLE
Fix inline GA fallback and desktop drawer focus handling

### DIFF
--- a/src/components/header/header2.astro
+++ b/src/components/header/header2.astro
@@ -65,6 +65,8 @@ import DesktopCart from '@/components/cart/DesktopCart';
         <button
           id="desktopCategoryToggle"
           aria-label="Toggle Categories"
+          aria-expanded="false"
+          aria-controls="desktopDrawerLeft"
           class="p-2 rounded-lg hover:text-primary"
         >
           <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -236,16 +238,33 @@ import DesktopCart from '@/components/cart/DesktopCart';
     let isDesktopLeftOpen = false;
 
     function openDesktopLeft() {
+      if (!desktopDrawerLeft || !desktopScrim) return;
       desktopDrawerLeft.classList.remove("hidden", "-translate-x-full", "invisible");
       desktopDrawerLeft.setAttribute('aria-hidden', 'false');
       desktopScrim.classList.remove("hidden", "pointer-events-none", "opacity-0");
+      desktopCategoryToggle?.setAttribute('aria-expanded', 'true');
       document.body.style.overflow = "hidden";
       isDesktopLeftOpen = true;
     }
 
     function closeDesktopLeft() {
+      if (!desktopDrawerLeft || !desktopScrim) return;
+      if (desktopDrawerLeft && document.activeElement && desktopDrawerLeft.contains(document.activeElement)) {
+        try {
+          document.activeElement.blur();
+        } catch {}
+      }
+
+      desktopCategoryToggle?.setAttribute('aria-expanded', 'false');
       desktopDrawerLeft.classList.add("-translate-x-full");
       desktopScrim.classList.add("opacity-0", "pointer-events-none");
+      requestAnimationFrame(() => {
+        if (desktopCategoryToggle) {
+          try {
+            desktopCategoryToggle.focus();
+          } catch {}
+        }
+      });
       setTimeout(() => {
         desktopScrim.classList.add("hidden");
         desktopDrawerLeft.classList.add("invisible");

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -225,39 +225,63 @@ const breadcrumbItems = shouldRenderBreadcrumbs
   <head>
     <!-- Google tag (gtag.js) -->
     <script is:inline type="text/javascript">
-      (function ensureRuntimeGlobals(global) {
-        if (!global || typeof global !== 'object') {
+      (function ensureRuntimeGlobals() {
+        var target =
+          typeof window !== 'undefined'
+            ? window
+            : typeof globalThis !== 'undefined'
+            ? globalThis
+            : undefined;
+
+        if (!target || typeof target !== 'object') {
           return;
         }
 
-        if (typeof global.__DEFINES__ === 'undefined' || global.__DEFINES__ === null) {
+        if (typeof target.__DEFINES__ === 'undefined' || target.__DEFINES__ === null) {
           try {
-            Object.defineProperty(global, '__DEFINES__', {
+            Object.defineProperty(target, '__DEFINES__', {
               value: {},
               writable: true,
               configurable: true,
               enumerable: false
             });
           } catch {
-            global.__DEFINES__ = {};
+            target.__DEFINES__ = {};
           }
         }
 
-        if (typeof global.inlineGaSetup !== 'function') {
-          const fallback = function inlineGaSetup() {
+        if (typeof target.inlineGaSetup !== 'function') {
+          var fallback = function inlineGaSetup() {
             return undefined;
           };
+
           try {
-            Object.defineProperty(global, 'inlineGaSetup', {
+            Object.defineProperty(target, 'inlineGaSetup', {
               value: fallback,
               writable: true,
               configurable: true
             });
           } catch {
-            global.inlineGaSetup = fallback;
+            target.inlineGaSetup = fallback;
+          }
+
+          if (typeof window !== 'undefined' && window !== target && typeof window.inlineGaSetup !== 'function') {
+            try {
+              window.inlineGaSetup = fallback;
+            } catch {
+              window.inlineGaSetup = fallback;
+            }
+          }
+
+          if (typeof globalThis !== 'undefined' && globalThis !== target && typeof globalThis.inlineGaSetup !== 'function') {
+            try {
+              globalThis.inlineGaSetup = fallback;
+            } catch {
+              globalThis.inlineGaSetup = fallback;
+            }
           }
         }
-      })(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : undefined);
+      })();
     </script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17641771829"></script>
     <script is:inline type="text/javascript">


### PR DESCRIPTION
## Summary
- ensure the inline GA setup helper is registered on all window/globalThis references before analytics scripts run
- improve the desktop navigation drawer toggle to manage focus and aria-expanded state when opening and closing

## Testing
- yarn lint *(fails: Type Error: Cannot destructure property 'version' of 'n[A]' as it is null.)*

------
https://chatgpt.com/codex/tasks/task_e_68fd18b62ca4832c88d0e41f9268da84