### PR TITLE
Handle install-only shipping class variants in cart and shipping flows

### DIFF
--- a/netlify/functions/getShippingQuoteBySkus.ts
+++ b/netlify/functions/getShippingQuoteBySkus.ts
@@ -164,7 +164,7 @@ export const handler: Handler = async (event) => {
       const weight = num(p?.shippingWeight, defaultWeight);
 
       if (normalizedClass === 'freight') freight = true;
-      if (normalizedClass === 'installonly') {
+      if (normalizedClass.includes('installonly')) {
         installOnly = true;
         continue;
       }

--- a/scripts/merchant/upload-google-merchant-feed.ts
+++ b/scripts/merchant/upload-google-merchant-feed.ts
@@ -716,7 +716,7 @@ function buildRows(products: any[], baseUrl: string, currency: string): Merchant
       const shippingClassRaw = sanitizeText(product?.shippingClass).toLowerCase();
       const normalizedClass = shippingClassRaw.replace(/[\s_-]+/g, '');
       const isInstallOnly =
-        normalizedClass === 'installonly' ||
+        normalizedClass.includes('installonly') ||
         filterSlugs.includes('install-only') ||
         filterSlugs.includes('install_only');
       const isPerformanceParts =

--- a/src/components/cart/DesktopCart.tsx
+++ b/src/components/cart/DesktopCart.tsx
@@ -152,8 +152,11 @@ function CartSummaryPopover({
               {items.map((item) => {
                 const lineTotal = (item.price || 0) * (item.quantity || 0);
                 const optionsSummary = listOptions(item.options);
-                const isInstallOnly =
-                  item.installOnly || (item.shippingClass || '').toLowerCase() === 'installonly';
+                const normalizedClass = (item.shippingClass || '')
+                  .toString()
+                  .toLowerCase()
+                  .replace(/[^a-z]/g, '');
+                const isInstallOnly = item.installOnly || normalizedClass.includes('installonly');
                 return (
                   <li key={item.id} className="flex gap-3 py-3">
                     <img

--- a/src/components/cart/ShippingEstimator.tsx
+++ b/src/components/cart/ShippingEstimator.tsx
@@ -356,7 +356,7 @@ export function ShippingEstimator({
   const identifyInstallOnly = (item: Cart['items'][number]) => {
     if (item.installOnly === true) return true;
     const cls = (item.shippingClass || '').toString().toLowerCase().replace(/[^a-z]/g, '');
-    return cls === 'installonly';
+    return cls.includes('installonly');
   };
 
   const cartInstallOnly = useMemo(

--- a/src/components/cart/modal.tsx
+++ b/src/components/cart/modal.tsx
@@ -260,8 +260,11 @@ function CartItemsList({ cart, onQuantityChange, onRemove }: CartItemsListProps)
           {items.map((item) => {
             const lineTotal = (item.price || 0) * (item.quantity || 0);
             const optionsSummary = listOptions(item.options as Record<string, unknown>);
-            const isInstallOnly =
-              item.installOnly || (item.shippingClass || '').toString().toLowerCase() === 'installonly';
+            const normalizedClass = (item.shippingClass || '')
+              .toString()
+              .toLowerCase()
+              .replace(/[^a-z]/g, '');
+            const isInstallOnly = item.installOnly || normalizedClass.includes('installonly');
             const productHref = (() => {
               const raw = item.productUrl;
               if (!raw) return undefined;

--- a/src/components/storefront/ShoppingCart.tsx
+++ b/src/components/storefront/ShoppingCart.tsx
@@ -63,9 +63,13 @@ function CartContents() {
 
   const installOnlyItems = useMemo(
     () =>
-      items.filter(
-        (item) => item.installOnly || (item.shippingClass || '').toLowerCase() === 'installonly'
-      ),
+      items.filter((item) => {
+        const normalizedClass = (item.shippingClass || '')
+          .toString()
+          .toLowerCase()
+          .replace(/[^a-z]/g, '');
+        return item.installOnly || normalizedClass.includes('installonly');
+      }),
     [items]
   );
 
@@ -137,8 +141,11 @@ function CartContents() {
               <ul className="divide-y divide-white/10">
                 {items.map((item) => {
                   const optionsSummary = listOptions(item.options);
-                  const isInstallOnly =
-                    item.installOnly || (item.shippingClass || '').toLowerCase() === 'installonly';
+                  const normalizedClass = (item.shippingClass || '')
+                    .toString()
+                    .toLowerCase()
+                    .replace(/[^a-z]/g, '');
+                  const isInstallOnly = item.installOnly || normalizedClass.includes('installonly');
                   const productHref = (() => {
                     const raw = item.productUrl;
                     if (!raw) return undefined;

--- a/src/pages/checkout/quick/[slug].ts
+++ b/src/pages/checkout/quick/[slug].ts
@@ -64,7 +64,7 @@ export const GET: APIRoute = async ({ params, request }) => {
   const normalizedClass = shippingClassRaw.toLowerCase().replace(/[^a-z0-9]+/g, '');
   const filterSlugs = collectFilterSlugs((product as any).filters);
   const hasInstallOnlyFilter = filterSlugs.includes('install-only') || filterSlugs.includes('installonly');
-  const installOnly = normalizedClass === 'installonly' || hasInstallOnlyFilter;
+  const installOnly = normalizedClass.includes('installonly') || hasInstallOnlyFilter;
 
   const cartPayload = {
     cart: [

--- a/src/pages/shop/[slug].astro
+++ b/src/pages/shop/[slug].astro
@@ -388,7 +388,7 @@ if (product) {
   const shippingClassRaw = ((product as any)?.shippingClass || '').toString();
   const normalizedShippingClass = shippingClassRaw.toLowerCase().replace(/[^a-z0-9]/g, '');
   const computedInstallOnly =
-    normalizedShippingClass === 'installonly' ||
+    normalizedShippingClass.includes('installonly') ||
     canonicalFilterSlugs.has('installonly') ||
     canonicalFilterSlugs.has('install-only');
   const computedPerformanceParts =
@@ -1202,7 +1202,7 @@ if (product) {
       const normalizedShippingClass = shippingClassRaw.toLowerCase().replace(/[^a-z]/g, '');
       const installOnlyFlag =
         String(ds.productInstallOnly || '').toLowerCase() === 'true' ||
-        normalizedShippingClass === 'installonly';
+        normalizedShippingClass.includes('installonly');
 
       // Stable config signature for line dedup (same options -> same line)
       const signature = JSON.stringify(selections.slice().sort((a,b)=>{

--- a/src/server/shipping/quote.ts
+++ b/src/server/shipping/quote.ts
@@ -56,7 +56,7 @@ const parseCarrierIds = (value?: unknown): string[] => {
   const str = String(value ?? '').trim();
   if (!str) return [];
 
-  if (/^[\[{]/.test(str)) {
+  if (str.startsWith('[') || str.startsWith('{')) {
     try {
       return parseCarrierIds(JSON.parse(str));
     } catch (err) {
@@ -64,9 +64,9 @@ const parseCarrierIds = (value?: unknown): string[] => {
     }
   }
 
-  const sanitized = str
-    .replace(/^["'\[\](){}<>\s]+/, '')
-    .replace(/["'\[\](){}<>\s]+$/, '');
+  const trimEdgeStartPattern = /^[\s"'()\u005b\u005d{}<>]+/;
+  const trimEdgeEndPattern = /[\s"'()\u005b\u005d{}<>]+$/;
+  const sanitized = str.replace(trimEdgeStartPattern, '').replace(trimEdgeEndPattern, '');
 
   const parts = sanitized
     .split(/[\s,]+/)
@@ -529,7 +529,7 @@ export async function computeShippingQuote(
     const normalizedClass = shippingClassRaw.replace(/[\s_-]+/g, '');
 
     if (normalizedClass === 'freight') freight = true;
-    if (normalizedClass === 'installonly') {
+    if (normalizedClass.includes('installonly')) {
       installOnly = true;
       continue;
     }


### PR DESCRIPTION
## Summary
- treat shipping classes containing "installonly" as install-only across storefront, checkout, and shipping quote logic
- ensure quick checkout, cart UI, and ShipEngine integration skip shipping for install-only packages
- keep merchant feed and server-side carrier parsing lint-compliant while supporting the broader install-only check

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68fe3e0159f8832cb51472c3da4ad09a