### PR TITLE
Improve product option selection contrast

### DIFF
--- a/src/pages/shop/[slug].astro
+++ b/src/pages/shop/[slug].astro
@@ -610,7 +610,7 @@ if (product) {
                               : (typeof v?.delta === 'number' ? v.delta : (typeof v?.price === 'number' ? v.price : 0)))
                           : 0;
                         return (
-                          <label class="flex items-center gap-2 bg-black/30 border border-white/20 rounded px-2 py-2 cursor-pointer">
+                          <label class="relative flex items-center gap-3 rounded-md border border-white/30 bg-black/40 px-3 py-2 text-white transition hover:border-white/50 hover:bg-black/55 focus-within:border-white/70 focus-within:ring-1 focus-within:ring-white/40 cursor-pointer">
                             <input
                               type="radio"
                               name={groupKey}
@@ -619,9 +619,12 @@ if (product) {
                               data-price={price}
                               data-label={label}
                               checked={i === 0}
+                              class="h-4 w-4 flex-shrink-0 accent-primary focus:ring-0"
                             />
-                            <span class="text-sm">{label}</span>
-                            <span class="ml-auto text-xs opacity-70">{price ? `+$${Number(price).toFixed(2)}` : ''}</span>
+                            <span class="flex-1 text-sm font-medium leading-snug text-white">{label}</span>
+                            <span class="ml-3 text-xs font-semibold text-white/70">
+                              {price ? `+$${Number(price).toFixed(2)}` : ''}
+                            </span>
                           </label>
                         );
                       })}
@@ -637,7 +640,7 @@ if (product) {
                 <div class="font-semibold mb-2">Optional Upgrades</div>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   {addOns.map((a: any) => (
-                    <label class="flex items-center gap-2 bg-black/30 border border-white/20 rounded px-2 py-2 cursor-pointer">
+                    <label class="relative flex items-center gap-3 rounded-md border border-white/30 bg-black/40 px-3 py-2 text-white transition hover:border-white/50 hover:bg-black/55 focus-within:border-white/70 focus-within:ring-1 focus-within:ring-white/40 cursor-pointer">
                       <input type="checkbox"
                         name={(a.key || 'upgrade').toString()}
                         value={(a.value || a.label || '').toString()}
@@ -645,9 +648,10 @@ if (product) {
                         data-price={(typeof a.priceDelta === 'number' ? a.priceDelta : 0).toString()}
                         data-label={a.label}
                         checked={!!a.defaultSelected}
+                        class="h-4 w-4 flex-shrink-0 accent-primary focus:ring-0"
                       />
-                      <span class="text-sm">{a.label}</span>
-                      <span class="ml-auto text-xs opacity-70">
+                      <span class="flex-1 text-sm font-medium leading-snug text-white">{a.label}</span>
+                      <span class="ml-3 text-xs font-semibold text-white/70">
                         {typeof a.priceDelta === 'number' && a.priceDelta !== 0
                           ? `+$${Number(a.priceDelta).toFixed(2)}`
                           : ''}


### PR DESCRIPTION
## Summary
- enhance the radio option cards with stronger contrast, spacing, and focus states so the labels remain readable
- style optional upgrade checkboxes to match the updated appearance and keep text from being obscured
- apply accent styling to the native inputs for better visibility when selected

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68fed31a94ec832c8abcb8d7ab2e2eda