### PR TITLE
Improve brand red contrast and muted text legibility

### DIFF
--- a/src/components/banner/HeadingBanner1.tsx
+++ b/src/components/banner/HeadingBanner1.tsx
@@ -25,7 +25,7 @@ export default function HeadingBanner1() {
         <div className="relative isolate overflow-hidden bg-white/5 border border-rounded rounded-lg border-black/20 drop-shadow-lg shadow-white/10 shadow-inner backdrop-blur-sm px-2 py-10 after:pointer-events-none after:absolute after:inset-0 after:inset-ring after:inset-ring-white/10 sm:rounded-3xl sm:px-10 sm:py-24 after:sm:rounded-3xl lg:py-24 xl:px-24">
           <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-2 lg:items-center lg:gap-y-0">
             <div className="lg:row-start-2 lg:max-w-md">
-              <h2 className="text-3xl font-semibold font-ethno tracking-tight text-balance text-white/40 sm:text-4xl">
+              <h2 className="text-3xl font-semibold font-ethno tracking-tight text-balance text-white/70 sm:text-4xl">
                 Custom Fabrication. Precision Engineering.
               </h2>
               <p className="mt-6 text-lg/8 text-white/70 font-mono">

--- a/src/components/banner/ProcessSection.tsx
+++ b/src/components/banner/ProcessSection.tsx
@@ -9,25 +9,25 @@ import {
 const steps = [
   {
     id: 1,
-    icon: <CalendarDateRangeIcon className="w-6 h-6 text-white/40" />,
+    icon: <CalendarDateRangeIcon className="w-6 h-6 text-white/70" />,
     title: 'Consult',
     desc: 'Define goals, constraints, budget, and intended use (street, track, work duty).'
   },
   {
     id: 2,
-    icon: <PencilIcon className="w-6 h-6 text-white/40" />,
+    icon: <PencilIcon className="w-6 h-6 text-white/70" />,
     title: 'Design',
     desc: 'On‑car measurement and CAD mock‑ups; choose materials, bends, joint types, and finish.'
   },
   {
     id: 3,
-    icon: <WrenchScrewdriverIcon className="w-6 h-6 text-white/40" />,
+    icon: <WrenchScrewdriverIcon className="w-6 h-6 text-white/70" />,
     title: 'Fabricate',
     desc: 'Mandrel bending, precision TIG welds with back purge; fixtures for repeatability.'
   },
   {
     id: 4,
-    icon: <CheckIcon className="w-6 h-6 text-white/40" />,
+    icon: <CheckIcon className="w-6 h-6 text-white/70" />,
     title: 'Install & Tune',
     desc: 'Fitment check, leak‑test, and final finish.'
   }

--- a/src/components/cart/modal.tsx
+++ b/src/components/cart/modal.tsx
@@ -135,7 +135,7 @@ export default function CartModal() {
                       <div className="flex-1 overflow-y-auto px-4 pb-6 sm:px-6">
                         {!cart || !cart.items || cart.items.length === 0 ? (
                           <div className="mt-16 flex flex-col items-center text-center">
-                            <ShoppingCartIcon className="h-16 w-16 text-white/40" />
+                            <ShoppingCartIcon className="h-16 w-16 text-white/70" />
                             <p className="mt-6 text-2xl font-semibold">Your cart is empty.</p>
                             <p className="mt-2 text-sm text-white/60">
                               Add products from the storefront to see them here.

--- a/src/components/packageComps/powerPackage.tsx
+++ b/src/components/packageComps/powerPackage.tsx
@@ -29,7 +29,7 @@ export default function PowerPackagesComponent() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl lg:mx-0">
           <h1 className="mt-2 text-4xl font-semibold tracking-tight text-pretty font-ethno italic text-primary sm:text-5xl">
-            Built to Pull Hard. <span className="text-white/40">Built to Last.</span>
+            Built to Pull Hard. <span className="text-white/70">Built to Last.</span>
           </h1>
           <p className="mt-6 text-xl text-gray-300">
             <span className="font-borg italic text-white">F.A.S. </span>

--- a/src/components/packageComps/truckPackage.tsx
+++ b/src/components/packageComps/truckPackage.tsx
@@ -30,7 +30,7 @@ export default function TruckPackagesComponent() {
         <div className="mx-auto max-w-2xl lg:mx-0">
           <h1 className="mt-2 text-4xl font-semibold tracking-tight text-pretty font-ethno italic text-primary sm:text-5xl">
             Truck Packages That Deliver.{' '}
-            <span className="text-white/40">Strength. Speed. Support.</span>
+            <span className="text-white/70">Strength. Speed. Support.</span>
           </h1>
           <p className="mt-6 text-xl text-gray-300">
             <span className="font-borg italic text-white">F.A.S. </span>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -110,7 +110,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
                     onClick={() => scrollToSection(item.id)}
                     className={`flex flex-col items-center justify-center min-w-0 flex-1 mobile-touch-target transition-colors duration-200 ${isActive ? 'text-primary' : 'text-white/60'}`}
                     whileTap={{ scale: 0.95 }}
-                    animate={{ scale: isActive ? 1.1 : 1, color: isActive ? '#ea1d26' : '#d1d0d0' }}
+                    animate={{ scale: isActive ? 1.1 : 1, color: isActive ? '#d11219' : '#d1d0d0' }}
                     transition={{ duration: 0.2 }}
                   >
                     <Icon

--- a/src/pages/dashboard/order/[id].astro
+++ b/src/pages/dashboard/order/[id].astro
@@ -804,7 +804,7 @@ const breadcrumbItems = [
                           <div class="mt-3 overflow-hidden rounded-full bg-white/10">
                             <div class="h-2 rounded-full bg-primary transition-all" style={`width: ${progressPercent};`} />
                           </div>
-                          <div class="mt-4 grid grid-cols-4 text-xs font-semibold uppercase tracking-wide text-white/40">
+                          <div class="mt-4 grid grid-cols-4 text-xs font-semibold uppercase tracking-wide text-white/60">
                             <span class={`text-left ${progressStep >= 0 ? 'text-primary' : ''}`}>Order placed</span>
                             <span class={`${progressStep >= 1 ? 'text-primary' : ''} text-center`}>Processing</span>
                             <span class={`${progressStep >= 2 ? 'text-primary' : ''} text-center`}>Shipped</span>
@@ -894,7 +894,7 @@ const breadcrumbItems = [
                           )}
                         </div>
                         {entry.createdAt && (
-                          <time class="text-xs text-white/40" datetime={entry.createdAt}>
+                          <time class="text-xs text-white/60" datetime={entry.createdAt}>
                             {formatDate(new Date(entry.createdAt))}
                           </time>
                         )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -215,7 +215,7 @@ table {
 
 :root {
   /* Custom brand colors */
-  --color-primary: #ea1d26;
+  --color-primary: #d11219;
   --color-secondary: #eef2fb;
   --color-accent: #fde4b2;
   --color-graylight: #d1d0d0;
@@ -237,7 +237,7 @@ table {
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(26.985% 0.07155 23.146);
-  --primary: #ea1d26;
+  --primary: #d11219;
   --primaryB: #7d0107;
   --primary-foreground: #ffffff;
   --secondary: #eef2fb;
@@ -264,7 +264,7 @@ table {
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: #7d0107;
-  --sidebar-primaryB: #ea1d26;
+  --sidebar-primaryB: #d11219;
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
@@ -284,7 +284,7 @@ table {
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(73.481% 0.00008 271.152);
   --popover-foreground: oklch(26.985% 0.07155 23.146);
-  --primary: #ea1d26;
+  --primary: #d11219;
   --primaryB: #7d0107;
   --primary-foreground: #ffffff;
   --secondary: #eef2fb;
@@ -311,7 +311,7 @@ table {
   --sidebar: oklch(55.208% 0.00006 271.152 / 0.295);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: #7d0107;
-  --sidebar-primaryB: #ea1d26;
+  --sidebar-primaryB: #d11219;
   --sidebar-primary-foreground: #ffffff91;
   --sidebar-accent: oklch(97.015% 0.00011 271.152 / 0.663);
   --sidebar-accent-foreground: oklch(66.984% 0.00008 271.152 / 0.652);
@@ -1070,7 +1070,7 @@ table {
   top: 0;
   bottom: 0;
   width: 4px;
-  background: linear-gradient(to bottom, transparent, #ea1d26, transparent);
+  background: linear-gradient(to bottom, transparent, #d11219, transparent);
   transform: translateX(-50%);
   opacity: 0.6;
   box-shadow: 0 0 10px rgba(234, 29, 38, 0.5);
@@ -2241,7 +2241,7 @@ html {
     border-color 200ms ease;
 
   /* Subtle glass */
-  background: rgba(112, 9, 9, 0.55);
+  background: rgba(209, 18, 25, 0.55);
   color: #fff;
   backdrop-filter: blur(10px) saturate(140%);
   -webkit-backdrop-filter: blur(10px) saturate(140%);
@@ -2262,7 +2262,7 @@ html {
     inset 0 1px 2px rgba(255, 255, 255, 0.08),
     inset 0 -2px 5px rgba(0, 0, 0, 0.55),
     0 6px 14px rgba(0, 0, 0, 0.55),
-    0 0 10px var(--btn-glow, rgba(234, 29, 38, 0.35));
+    0 0 10px var(--btn-glow, rgba(209, 18, 25, 0.35));
 }
 
 /* Active: micro press */
@@ -2275,15 +2275,15 @@ html {
 
 /* Focus ring without thick borders */
 .btn-glass:focus-visible {
-  outline: 2px solid var(--btn-glow, rgba(234, 29, 38, 0.4));
+  outline: 2px solid var(--btn-glow, rgba(209, 18, 25, 0.4));
   outline-offset: 2px;
 }
 
 /* Scoped color variants (won't collide with other .btn-* classes) */
 .btn-glass.btn-primary {
-  --btn-glow: rgba(234, 29, 38, 0.5);
-  background: rgba(234, 29, 38, 0.16);
-  border-color: rgba(234, 29, 38, 0.35);
+  --btn-glow: rgba(209, 18, 25, 0.55);
+  background: rgba(209, 18, 25, 0.85);
+  border-color: rgba(209, 18, 25, 0.9);
 }
 
 .btn-glass.btn-secondary {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,7 +50,7 @@ module.exports = {
     extend: {
       colors: {
         // Brand palette used by utilities like text-primary, bg-accent, etc.
-        primary: '#ea1d26',
+        primary: '#d11219',
         secondary: '#eef2fb',
         red: '#7d0107',
         accent: '#fde4b2',


### PR DESCRIPTION
## Summary
- darken the brand primary red across the Tailwind theme and global CSS variables so links and buttons meet contrast requirements
- increase opacity on glass buttons, hero headings, process icons, and other muted text so labels remain readable on dark surfaces
- bump dashboard progress labels and the empty-cart illustration to higher contrast values for accessibility

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68fef499e9a0832c9b2d0179a152c6bf