### PR TITLE
Fix invalid image URL handling on order detail page

### DIFF
--- a/src/pages/dashboard/order/[id].astro
+++ b/src/pages/dashboard/order/[id].astro
@@ -398,7 +398,10 @@ function pickImageUrl(candidate: unknown, seen = new Set<unknown>()): string | n
       if (built) return built;
     }
     if (/^https?:/i.test(trimmed)) return trimmed;
-    return trimmed;
+    if (/^(?:\/|\.\/|\.\.\/)/.test(trimmed)) return trimmed;
+    if (/^data:image\//i.test(trimmed)) return trimmed;
+    if (/^blob:/i.test(trimmed)) return trimmed;
+    return null;
   }
   if (seen.has(candidate)) return null;
   seen.add(candidate);


### PR DESCRIPTION
## Summary
- update the order detail image resolver to ignore malformed non-URL strings
- allow recognized http(s), relative, data, and blob URLs while falling back to the placeholder when needed

## Testing
- yarn lint src/pages/dashboard/order/[id].astro

------
https://chatgpt.com/codex/tasks/task_e_6900119abee0832c8b9b0bcef0035321