### PR TITLE
Improve dashboard order item image resolution

### DIFF
--- a/src/scripts/dashboard-page.ts
+++ b/src/scripts/dashboard-page.ts
@@ -62,7 +62,10 @@ function resolveOrderItemImage(item: any): string {
   if (!item) return FALLBACK_ITEM_IMAGE;
   const product = item.product ?? {};
   const price = item.price ?? {};
-  const priceProduct = typeof price.product === 'object' ? price.product : {};
+  const priceProduct =
+    price && typeof price.product === 'object' && price.product !== null
+      ? price.product
+      : {};
 
   const productImages = Array.isArray(product.images) ? product.images : [];
   const priceProductImages = Array.isArray(priceProduct.images)


### PR DESCRIPTION
## Summary
- guard dashboard order item price product resolution against null price.product values to avoid runtime errors when reading images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690037104bf8832cbe7f33868bddef61