### PR TITLE
Fix visual editing host allowlist detection

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ import CookieBanner from '@/components/notices/cookieBanner';
 import Breadcrumbs from '@/components/storefront/Breadcrumbs.astro';
 import { Toaster } from 'sonner';
 import VisualEditingBridge from '@/components/sanity/VisualEditingBridge';
-import { visualEditingHostAllowlisted } from '@/lib/sanity-utils';
+import { isVisualEditingHostnameAllowlisted } from '@/lib/sanity-utils';
 
 
 // SEO props (optional per-page)
@@ -77,6 +77,16 @@ try {
 } catch {
   currentUrl = null;
 }
+
+const requestHostnameRaw =
+  currentUrl?.hostname ||
+  Astro.request.headers.get('x-forwarded-host') ||
+  Astro.request.headers.get('host') ||
+  null;
+const requestHostname = requestHostnameRaw
+  ? requestHostnameRaw.split(':')[0]?.trim().toLowerCase() ?? null
+  : null;
+const visualEditingHostAllowlisted = isVisualEditingHostnameAllowlisted(requestHostname);
 
 const envVisualEditingRequested = parseBooleanFlag(
   import.meta.env.PUBLIC_SANITY_ENABLE_VISUAL_EDITING as string | undefined

--- a/src/lib/sanity-utils.ts
+++ b/src/lib/sanity-utils.ts
@@ -148,12 +148,21 @@ const visualEditingAllowedHosts = new Set<string>([
 const isBrowserRuntime = typeof window !== 'undefined' && typeof window.location !== 'undefined';
 const runtimeHostname = isBrowserRuntime ? window.location.hostname.toLowerCase() : undefined;
 
-const visualEditingOriginAllowed =
-  !isBrowserRuntime || visualEditingAllowedHosts.size === 0
-    ? true
-    : runtimeHostname
-    ? visualEditingAllowedHosts.has(runtimeHostname)
-    : false;
+const isHostnameAllowlisted = (hostname: string | null | undefined): boolean => {
+  const normalized = typeof hostname === 'string' ? hostname.trim().toLowerCase() : undefined;
+
+  if (!normalized) {
+    return visualEditingAllowedHosts.size === 0;
+  }
+
+  if (visualEditingAllowedHosts.size === 0) {
+    return true;
+  }
+
+  return visualEditingAllowedHosts.has(normalized);
+};
+
+const visualEditingOriginAllowed = isHostnameAllowlisted(runtimeHostname);
 
 const visualEditingRequested = toBooleanFlag(
   import.meta.env.PUBLIC_SANITY_ENABLE_VISUAL_EDITING as string | undefined
@@ -389,6 +398,8 @@ export const visualEditingEnabled = stegaEnabled;
 export const previewDraftsActive = previewDraftsEnabled;
 export const liveSubscriptionsEnabled = stegaEnabled && liveSubscriptionsFlag;
 
+export const isVisualEditingHostnameAllowlisted = (hostname: string | null | undefined): boolean =>
+  isHostnameAllowlisted(hostname);
 export const visualEditingHostAllowlisted = visualEditingOriginAllowed;
 export const visualEditingRequestedFlag = visualEditingRequested;
 


### PR DESCRIPTION
## Summary
- normalize runtime host checking to reuse the Sanity visual editing allowlist logic
- ensure the Astro layout evaluates the current request hostname against the allowlist before enabling visual editing live subscriptions

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_690075eeef88832c88e16a59aa1fa09e