### PR TITLE
Improve text contrast for primary buttons and CTAs

### DIFF
--- a/src/components/appointmentCard.astro
+++ b/src/components/appointmentCard.astro
@@ -25,7 +25,7 @@ const {
       {(rescheduleUrl || cancelUrl) && (
         <div class="flex space-x-2">
           {rescheduleUrl && (
-            <a href={rescheduleUrl} target="_blank" rel="noopener noreferrer" class="inline-block px-4 py-2 text-sm border border-yellow-500 text-yellow-500 hover:bg-yellow-500 hover:text-accent transition rounded">
+            <a href={rescheduleUrl} target="_blank" rel="noopener noreferrer" class="inline-block px-4 py-2 text-sm border border-yellow-400 text-yellow-300 hover:bg-yellow-500 hover:text-gray-900 transition rounded">
               Reschedule
             </a>
           )}

--- a/src/components/storefront/ProductGrid.astro
+++ b/src/components/storefront/ProductGrid.astro
@@ -16,6 +16,6 @@ const { products = [], emptyMessage = 'No products found.', view = 'grid' } = As
   <div class="mt-10 flex flex-col items-center justify-center rounded-xl border border-white/20 bg-black/60 px-6 py-12 text-center text-white/80">
     <div class="font-ethno text-white text-lg">{emptyMessage}</div>
     <div class="mt-3 text-sm text-white/70">Try removing a filter or browsing all products.</div>
-    <a href="/shop" class="mt-5 inline-flex items-center justify-center rounded-fx-md bg-primary px-4 py-2 font-semibold text-accent hover:bg-primary/90">Clear filters</a>
+    <a href="/shop" class="mt-5 inline-flex items-center justify-center rounded-fx-md bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 hover:text-white">Clear filters</a>
   </div>
 )}

--- a/src/components/storefront/ProductInfoPanel.astro
+++ b/src/components/storefront/ProductInfoPanel.astro
@@ -84,7 +84,7 @@ function hiddenInput(name: string, value: string) {
     <h1 class="font-ethno text-2xl md:text-3xl">{title}</h1>
     <div class="mt-2 flex flex-wrap gap-2">
       {sku && (<span class="rounded-full border border-white/15 px-2 py-0.5 text-xs text-white/70">SKU: {sku}</span>)}
-      {isFeatured && (<span class="rounded-full bg-primary px-2 py-0.5 text-xs text-accent">Featured</span>)}
+      {isFeatured && (<span class="rounded-full bg-primary px-2 py-0.5 text-xs text-white">Featured</span>)}
       {badges.map((b) => (<span class="rounded-full border border-white/15 px-2 py-0.5 text-xs text-white/70">{b}</span>))}
     </div>
   </div>
@@ -110,7 +110,7 @@ function hiddenInput(name: string, value: string) {
     ))}
 
     <div class="flex items-center gap-2">
-      <button type="submit" class="inline-flex items-center justify-center rounded-fx-md bg-primary px-5 py-2 font-semibold text-accent hover:bg-primary/90">
+      <button type="submit" class="inline-flex items-center justify-center rounded-fx-md bg-primary px-5 py-2 font-semibold text-white hover:bg-primary/90 hover:text-white">
         Add to Cart
       </button>
       <a href="/contact" class="inline-flex items-center justify-center rounded-fx-md border border-white/30 px-4 py-2 hover:bg-white/80">

--- a/src/pages/account/edit.astro
+++ b/src/pages/account/edit.astro
@@ -51,7 +51,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
         </fieldset>
 
         <div class="pt-2">
-          <button type="submit" class="rounded bg-primary px-4 py-2 text-accent hover:bg-primary/90">Submit Changes</button>
+          <button type="submit" class="rounded bg-primary px-4 py-2 text-white hover:bg-primary/90 hover:text-white">Submit Changes</button>
         </div>
         <p id="account-edit-status" class="hidden text-sm mt-3"></p>
       </form>

--- a/src/pages/account/edit/success.astro
+++ b/src/pages/account/edit/success.astro
@@ -7,7 +7,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     <div class="max-w-md bg-[#121212] border border-gray-700 rounded-lg p-8 shadow-lg">
       <h1 class="text-2xl font-ethno text-accent mb-3">Thanks!</h1>
       <p class="text-white/60">Your account update request was submitted. Our team will process it shortly.</p>
-      <a href="/account" class="inline-block mt-6 px-4 py-2 bg-primary text-accent rounded">Back to Account</a>
+      <a href="/account" class="inline-block mt-6 px-4 py-2 bg-primary text-white rounded hover:text-white">Back to Account</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/account/forgot-password.astro
+++ b/src/pages/account/forgot-password.astro
@@ -24,7 +24,7 @@ const title = 'Forgot Password';
         </div>
         <button
           type="submit"
-          class="w-full bg-primary text-accent font-ethno rounded px-3 py-2 hover:bg-primary/80 transition"
+          class="w-full bg-primary text-white font-ethno rounded px-3 py-2 hover:bg-primary/80 hover:text-white transition"
         >
           Send reset link
         </button>

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -28,7 +28,7 @@ const pageDescription = isLoggedIn
         <h1 class="text-2xl font-ethno text-primary mb-2">Account</h1>
         <p class="mb-4">You are signed in.</p>
         <div class="flex gap-3">
-          <a href="/dashboard" class="px-4 py-2 rounded bg-primary text-accent font-ethno">Go to Dashboard</a>
+          <a href="/dashboard" class="px-4 py-2 rounded bg-primary text-white font-ethno hover:text-white">Go to Dashboard</a>
           <a href="/api/auth/logout" class="px-4 py-2 rounded border border-white/30 font-ethno">Logout</a>
         </div>
       </section>
@@ -55,7 +55,7 @@ const pageDescription = isLoggedIn
               <a href="/account/forgot-password" class="text-primary hover:text-primary/80">Forgot password?</a>
             </div>
           </div>
-          <button type="submit" class="px-4 py-2 rounded bg-primary text-accent font-ethno">Sign in</button>
+          <button type="submit" class="px-4 py-2 rounded bg-primary text-white font-ethno hover:text-white">Sign in</button>
         </form>
         <form id="fas-signup" class="space-y-3 max-w-sm hidden">
           <div>
@@ -70,7 +70,7 @@ const pageDescription = isLoggedIn
             <label class="block text-sm mb-1">Password</label>
             <input type="password" name="password" required minlength="8" class="w-full bg-white/5 border border-white/15 rounded px-3 py-2" />
           </div>
-          <button type="submit" class="px-4 py-2 rounded bg-primary text-accent font-ethno">Create account</button>
+          <button type="submit" class="px-4 py-2 rounded bg-primary text-white font-ethno hover:text-white">Create account</button>
         </form>
         <div id="auth-message" class="mt-4 hidden rounded-md border px-4 py-3 text-sm"></div>
         <script>

--- a/src/pages/account/reset.astro
+++ b/src/pages/account/reset.astro
@@ -44,7 +44,7 @@ const invalid = !token || !email;
             </div>
             <button
               type="submit"
-              class="w-full bg-primary text-accent font-ethno rounded px-3 py-2 hover:bg-primary/80 transition"
+              class="w-full bg-primary text-white font-ethno rounded px-3 py-2 hover:bg-primary/80 hover:text-white transition"
             >
               Update password
             </button>

--- a/src/pages/appointments/confirm.astro
+++ b/src/pages/appointments/confirm.astro
@@ -16,7 +16,7 @@ import BookingConfirm from '../../components/BookingConfirm.jsx';
       <BookingConfirm client:only="react" />
 
       <div class="mt-8">
-        <a href="/" class="inline-block px-6 py-3 bg-white text-accent font-semibold rounded hover:bg-gray-300 transition">
+        <a href="/" class="inline-block px-6 py-3 bg-white text-gray-900 font-semibold rounded hover:bg-gray-300 hover:text-gray-900 transition">
           Return to Home
         </a>
       </div>

--- a/src/pages/appointments/history.astro
+++ b/src/pages/appointments/history.astro
@@ -38,7 +38,7 @@ const pastAppointments = appointments.filter((a: Appointment) => new Date(a.star
                   </div>
                   <div class="mt-4 md:mt-0 space-x-2">
                     <a href={appt.cancelUrl} target="_blank" rel="noopener noreferrer" class="inline-block px-4 py-2 text-sm border border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition rounded">Cancel</a>
-                    <a href={appt.rescheduleUrl} target="_blank" rel="noopener noreferrer" class="inline-block px-4 py-2 text-sm border border-yellow-500 text-yellow-500 hover:bg-yellow-500 hover:text-accent transition rounded">Reschedule</a>
+                    <a href={appt.rescheduleUrl} target="_blank" rel="noopener noreferrer" class="inline-block px-4 py-2 text-sm border border-yellow-400 text-yellow-300 hover:bg-yellow-500 hover:text-gray-900 transition rounded">Reschedule</a>
                   </div>
                 </div>
               </li>

--- a/src/pages/contact/success.astro
+++ b/src/pages/contact/success.astro
@@ -7,7 +7,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     <div class="max-w-md bg-[#121212] border border-gray-700 rounded-lg p-8 shadow-lg">
       <h1 class="text-2xl font-cyber text-accent mb-3">Thank you!</h1>
       <p class="text-white/60">Your message has been received. We’ll get back to you shortly.</p>
-      <a href="/" class="inline-block mt-6 px-4 py-2 bg-primary text-accent rounded">Back to home</a>
+      <a href="/" class="inline-block mt-6 px-4 py-2 bg-primary text-white rounded hover:text-white">Back to home</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/customerdashboard/customerProfile.astro
+++ b/src/pages/customerdashboard/customerProfile.astro
@@ -61,7 +61,7 @@ const profileScript = '../../scripts/customer-profile-page.ts';
           </label>
         </div>
         <div class="mt-6 flex gap-3 items-center">
-          <button id="saveProfile" type="button" class="px-4 py-2 bg-primary text-accent font-ethno disabled:opacity-60 disabled:cursor-not-allowed active:scale-[0.98] transition-transform">
+          <button id="saveProfile" type="button" class="px-4 py-2 bg-primary text-white font-ethno disabled:opacity-60 disabled:cursor-not-allowed active:scale-[0.98] transition-transform hover:text-white">
             Save
           </button>
           <button id="revertProfile" type="button" class="px-4 py-2 border border-white/30 font-ethno active:scale-[0.98] transition-transform">
@@ -124,7 +124,7 @@ const profileScript = '../../scripts/customer-profile-page.ts';
         <label class="flex items-center gap-2"><input type="checkbox" name="marketingOptIn" value="yes" /> Marketing emails</label>
       </fieldset>
 
-      <button type="submit" class="rounded bg-primary px-4 py-2 text-accent hover:bg-primary/90">Submit Request</button>
+      <button type="submit" class="rounded bg-primary px-4 py-2 text-white hover:bg-primary/90 hover:text-white">Submit Request</button>
       <p id="profile-form-status" class="hidden text-sm mt-3"></p>
     </form>
   </section>

--- a/src/pages/customerdashboard/profile/success.astro
+++ b/src/pages/customerdashboard/profile/success.astro
@@ -7,7 +7,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     <div class="max-w-md bg-[#121212] border border-gray-700 rounded-lg p-8 shadow-lg">
       <h1 class="text-2xl font-ethno text-accent mb-3">Thanks!</h1>
       <p class="text-white/60">Your profile update request was submitted. We’ll review it shortly.</p>
-      <a href="/dashboard" class="inline-block mt-6 px-4 py-2 bg-primary text-accent rounded">Back to Dashboard</a>
+      <a href="/dashboard" class="inline-block mt-6 px-4 py-2 bg-primary text-white rounded hover:text-white">Back to Dashboard</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/customerdashboard/userOrders.astro
+++ b/src/pages/customerdashboard/userOrders.astro
@@ -45,7 +45,7 @@ import RequireLogin from '../../components/RequireLogin.jsx';
                 <textarea id="message" name="message" rows="4" class="w-full rounded bg-white/5 border border-white/15 p-2"></textarea>
               </div>
             </div>
-            <button type="submit" class="rounded bg-primary px-4 py-2 text-accent hover:bg-primary/90">Send</button>
+            <button type="submit" class="rounded bg-primary px-4 py-2 text-white hover:bg-primary/90 hover:text-white">Send</button>
             <p id="order-support-status" class="hidden text-sm mt-3"></p>
           </form>
         </div>

--- a/src/pages/orders/support/success.astro
+++ b/src/pages/orders/support/success.astro
@@ -7,7 +7,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
     <div class="max-w-md bg-[#121212] border border-gray-700 rounded-lg p-8 shadow-lg">
       <h1 class="text-2xl font-ethno text-accent mb-3">Request received</h1>
       <p class="text-white/60">Your order support request has been sent. We’ll reply to your email.</p>
-      <a href="/customerdashboard/userOrders" class="inline-block mt-6 px-4 py-2 bg-primary text-accent rounded">Back to Orders</a>
+      <a href="/customerdashboard/userOrders" class="inline-block mt-6 px-4 py-2 bg-primary text-white rounded hover:text-white">Back to Orders</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -58,8 +58,8 @@ const structuredData = {
           Pick a time that fits your schedule. We’ll confirm, prep parts, and have your vehicle ready on time.
         </p>
         <div class="mt-6 flex gap-3">
-          <a href="#book" class="inline-flex items-center px-5 py-2.5 rounded-full bg-[#FFA800] text-accent font-ethno hover:bg-[#ffb833] transition">Book now</a>
-          <a href="#faq" class="inline-flex items-center px-5 py-2.5 rounded-full border border-[#FFA800] text-[#FFA800] font-ethno hover:bg-[#FFA800] hover:text-accent transition">FAQ</a>
+          <a href="#book" class="inline-flex items-center px-5 py-2.5 rounded-full bg-[#FFA800] text-gray-900 font-ethno hover:bg-[#ffb833] hover:text-gray-900 transition">Book now</a>
+          <a href="#faq" class="inline-flex items-center px-5 py-2.5 rounded-full border border-[#FFA800] text-[#FFA800] font-ethno hover:bg-[#FFA800] hover:text-gray-900 transition">FAQ</a>
         </div>
       </div>
     </section>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -61,7 +61,7 @@ if (endPage < totalPages) {
       placeholder="Search..."
       class="bg-transparent border-b focus:border-white text-white placeholder:text-white/80 font-ethno focus:outline-none w-full sm:w-96 py-1"
     />
-    <button type="submit" class="px-4 py-1 bg-primary text-accent font-ethno rounded">Search</button>
+    <button type="submit" class="px-4 py-1 bg-primary text-white font-ethno rounded hover:text-white">Search</button>
   </form>
   <p id="query-label" class="mt-2 text-sm text-white/70"></p>
 </div>

--- a/src/pages/services/Services.astro
+++ b/src/pages/services/Services.astro
@@ -33,7 +33,7 @@ const pageDescription = 'Professional installs, tuning, fabrication, diagnostics
           <p class="text-white/70 font-mono font-bold text-base leading-6 tracking-[0.32px] mb-8 max-w-[523px]">
             Expert performance tuning, custom fabrication, and precision installations. From supercharger upgrades to security systems, we deliver professional automotive solutions with OEM-level quality and warranty-friendly installations.
           </p>
-          <a href="/schedule" class="inline-flex items-center justify-center px-6 py-3 bg-[#FFA800] text-accent font-cyber text-sm font-normal uppercase tracking-wider rounded-full hover:bg-[#FFA800]/90 transition-colors">
+          <a href="/schedule" class="inline-flex items-center justify-center px-6 py-3 bg-[#FFA800] text-gray-900 font-cyber text-sm font-normal uppercase tracking-wider rounded-full hover:bg-[#FFA800]/90 hover:text-gray-900 transition-colors">
             Schedule Service
           </a>
         </div>
@@ -181,7 +181,7 @@ const pageDescription = 'Professional installs, tuning, fabrication, diagnostics
 
     <!-- CTA Button -->
     <section class="py-16 px-16 text-center">
-      <a href="/schedule" class="inline-flex items-center justify-center px-6 py-3 border border-[#FFA800] text-[#FFA800] font-body text-sm font-normal uppercase tracking-wider rounded-full hover:bg-[#FFA800] hover:text-accent transition-colors">
+      <a href="/schedule" class="inline-flex items-center justify-center px-6 py-3 border border-[#FFA800] text-[#FFA800] font-body text-sm font-normal uppercase tracking-wider rounded-full hover:bg-[#FFA800] hover:text-gray-900 transition-colors">
         Schedule Service
       </a>
     </section>

--- a/src/pages/shop/[slug].astro
+++ b/src/pages/shop/[slug].astro
@@ -701,7 +701,7 @@ if (product) {
         <button
           id="add-to-cart-btn"
           type="button"
-          class="add-to-cart inline-flex items-center gap-2 border border-white/30 px-4 py-2 rounded-full hover:bg-primary hover:text-accent transition relative z-10 pointer-events-auto"
+          class="add-to-cart inline-flex items-center gap-2 border border-white/30 px-4 py-2 rounded-full hover:bg-primary hover:text-white transition relative z-10 pointer-events-auto"
           data-product-id={(product as any)._id}
           data-product-name={(product as any).title}
           data-product-price={typeof priceValue === 'number' ? priceValue.toFixed(2) : undefined}
@@ -1048,7 +1048,7 @@ if (product) {
   </div>
   <button
     type="button"
-    class="add-to-cart inline-flex items-center gap-2 bg-primary text-accent font-ethno px-4 py-2 rounded"
+    class="add-to-cart inline-flex items-center gap-2 bg-primary text-white font-ethno px-4 py-2 rounded hover:text-white"
     data-product-id={(product as any)._id}
     data-product-name={(product as any).title}
     data-product-price={typeof priceValue === 'number' ? priceValue.toFixed(2) : undefined}
@@ -1107,7 +1107,7 @@ if (product) {
         The product you are looking for may have been removed, renamed, or is temporarily unavailable.
       </p>
       <a
-        class="mt-8 inline-flex items-center rounded-full border border-white/30 px-5 py-2 text-sm uppercase tracking-wide transition hover:bg-primary hover:text-accent"
+        class="mt-8 inline-flex items-center rounded-full border border-white/30 px-5 py-2 text-sm uppercase tracking-wide transition hover:bg-primary hover:text-white"
         href="/shop"
       >
         Browse all products


### PR DESCRIPTION
## Summary
- Adjusted primary action buttons across account and dashboard flows to use high-contrast text colors.
- Updated yellow call-to-action links and appointment reschedule buttons to maintain accessible contrast in all states.
- Ensured storefront featured badges and add-to-cart controls use readable foreground colors against their backgrounds.

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6900844340e0832c8b817efae1afb5b9