### PR TITLE
Enhance SEO metadata and schema

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -183,7 +183,7 @@ const resolvedDescription =
     : DEFAULT_DESCRIPTION;
 
 const normalizeKeywords = (value: string | string[] | undefined) => {
-  if (!value) return [] as string[];
+  if (!value) return [];
   if (Array.isArray(value)) {
     return value
       .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,7 +18,8 @@ const {
   noindex: rawNoindex = false,
   ogImage,
   hideBreadcrumbs = false,
-  breadcrumbs
+  breadcrumbs,
+  keywords
 } = Astro.props as {
   title?: string;
   description?: string;
@@ -27,6 +28,7 @@ const {
   ogImage?: string;
   hideBreadcrumbs?: boolean;
   breadcrumbs?: Array<{ href?: string; label: string }>;
+  keywords?: string | string[];
 };
 
 const normalizeNoindex = (value: unknown): boolean => {
@@ -46,6 +48,20 @@ const noindex = normalizeNoindex(rawNoindex);
 const robotsContent = noindex ? 'noindex,follow' : 'index,follow';
 
 const SITE_NAME = 'F.A.S. Motorsports';
+const SITE_AUTHOR = 'F.A.S. Motorsports';
+const DEFAULT_DESCRIPTION =
+  'F.A.S. Motorsports delivers premium performance parts, custom fabrication, installs, and wheel packages in Fort Myers, Florida.';
+const DEFAULT_KEYWORDS = [
+  'F.A.S. Motorsports',
+  'performance parts',
+  'supercharger upgrades',
+  'billet parts',
+  'custom fabrication',
+  'Fort Myers auto shop',
+  'Hellcat performance',
+  'Trackhawk upgrades',
+  'TRX packages'
+];
 const DEFAULT_OG_IMAGE = 'https://fasmotorsports.com/images/social/social-share.webp';
 
 const parseBooleanFlag = (value: unknown): boolean => {
@@ -161,6 +177,27 @@ try {
 
 const resolvedOgImage = ogImage ?? DEFAULT_OG_IMAGE;
 const pageTitle = title ? `${title} | ${SITE_NAME}` : SITE_NAME;
+const resolvedDescription =
+  typeof description === 'string' && description.trim().length > 0
+    ? description.trim()
+    : DEFAULT_DESCRIPTION;
+
+const normalizeKeywords = (value: string | string[] | undefined) => {
+  if (!value) return [] as string[];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean);
+  }
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+};
+
+const keywordList = normalizeKeywords(keywords);
+const resolvedKeywords = keywordList.length ? keywordList : DEFAULT_KEYWORDS;
+const keywordsContent = resolvedKeywords.join(', ');
 
 const sanitizeSegment = (segment: string) => {
   const decoded = decodeURIComponent(segment);
@@ -238,6 +275,44 @@ const breadcrumbItems = shouldRenderBreadcrumbs
       )
     )
   : [];
+
+const toAbsoluteUrl = (value?: string) => {
+  if (!value) return undefined;
+  try {
+    if (/^https?:\/\//i.test(value)) {
+      return new URL(value).toString();
+    }
+    if (canonicalUrl) {
+      return new URL(value, canonicalUrl).toString();
+    }
+    if (currentUrl) {
+      return new URL(value, currentUrl).toString();
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
+const breadcrumbStructuredData =
+  breadcrumbItems.length > 0
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: breadcrumbItems.map((item, index) => {
+          const entry: Record<string, any> = {
+            '@type': 'ListItem',
+            position: index + 1,
+            name: item.label
+          };
+          const absolute = toAbsoluteUrl(item.href);
+          if (absolute) {
+            entry.item = absolute;
+          }
+          return entry;
+        })
+      }
+    : null;
 ---
 
 <!DOCTYPE html>
@@ -384,19 +459,31 @@ const breadcrumbItems = shouldRenderBreadcrumbs
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#09090b" />
     <title>{pageTitle}</title>
-    {description && <meta name="description" content={description} />}
+    <meta name="description" content={resolvedDescription} />
+    <meta name="author" content={SITE_AUTHOR} />
+    <meta name="keywords" content={keywordsContent} />
     <meta name="robots" content={robotsContent} />
     {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     <meta property="og:site_name" content={SITE_NAME} />
     <meta property="og:type" content="website" />
     <meta property="og:title" content={title ? `${title}` : SITE_NAME} />
-    {description && <meta property="og:description" content={description} />}
+    {resolvedDescription && (
+      <meta property="og:description" content={resolvedDescription} />
+    )}
     {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
     {resolvedOgImage && <meta property="og:image" content={resolvedOgImage} />}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title ? `${title}` : SITE_NAME} />
-    {description && <meta name="twitter:description" content={description} />}
+    {resolvedDescription && (
+      <meta name="twitter:description" content={resolvedDescription} />
+    )}
     {resolvedOgImage && <meta name="twitter:image" content={resolvedOgImage} />}
+    {breadcrumbStructuredData && (
+      <script
+        type="application/ld+json"
+        set:html={JSON.stringify(breadcrumbStructuredData)}
+      />
+    )}
     <script is:inline type="module">
       (function () {
         if (typeof window === 'undefined') return;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -180,7 +180,7 @@ const webSiteSchema = {
   url: canonicalHome,
   potentialAction: {
     '@type': 'SearchAction',
-    target: `${canonicalHome}search?query={search_term_string}`,
+    target: `${canonicalHome}search?q={search_term_string}`,
     'query-input': 'required name=search_term_string'
   }
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,6 +14,8 @@ import SectionRenderer from '@/components/SectionRenderer.astro';
 
 
 const url = new URL(Astro.request.url);
+const siteOrigin = url.origin;
+const canonicalHome = `${siteOrigin}/`;
 const pageDoc: any = await loadPageDoc('index');
 const v2Param = url.searchParams.get('v2');
 // Default to the new V2 homepage; allow opt-out via ?v2=0
@@ -120,15 +122,149 @@ const featuredProductsNormalized = Array.isArray(featuredProducts)
       return { ...product, imageUrl: normalizedImageUrl };
     })
   : [];
+
+const organizationSchema = {
+  '@type': 'Organization',
+  '@id': '#fas-organization',
+  name: 'F.A.S. Motorsports',
+  legalName: 'F.A.S. Motorsports',
+  url: canonicalHome,
+  logo: `${siteOrigin}/logo/faslogochroma.webp`,
+  sameAs: [
+    'https://www.facebook.com/fasmotorsports',
+    'https://www.instagram.com/fasmotorsports'
+  ]
+};
+
+const localBusinessSchema = {
+  '@type': 'AutoRepair',
+  '@id': '#fas-location',
+  name: 'F.A.S. Motorsports',
+  url: canonicalHome,
+  telephone: '(812) 200-9012',
+  email: 'sales@fasmotorsports.com',
+  image: 'https://fasmotorsports.com/images/social/social-share.webp',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: '6161 Riverside Dr',
+    addressLocality: 'Fort Myers',
+    addressRegion: 'FL',
+    postalCode: '33982',
+    addressCountry: 'US'
+  },
+  openingHoursSpecification: [
+    {
+      '@type': 'OpeningHoursSpecification',
+      dayOfWeek: [
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday'
+      ],
+      opens: '09:00',
+      closes: '17:00'
+    }
+  ],
+  sameAs: [
+    'https://www.facebook.com/fasmotorsports',
+    'https://www.instagram.com/fasmotorsports'
+  ],
+  parentOrganization: { '@id': '#fas-organization' }
+};
+
+const webSiteSchema = {
+  '@type': 'WebSite',
+  '@id': '#fas-website',
+  name: 'F.A.S. Motorsports',
+  url: canonicalHome,
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: `${canonicalHome}search?query={search_term_string}`,
+    'query-input': 'required name=search_term_string'
+  }
+};
+
+const webPageSchema = {
+  '@type': 'WebPage',
+  '@id': '#fas-homepage',
+  name: 'F.A.S. Motorsports Performance Parts & Packages',
+  url: canonicalHome,
+  isPartOf: { '@id': '#fas-website' },
+  about: { '@id': '#fas-organization' }
+};
+
+const productSchemas = featuredProductsNormalized
+  .map((product, index) => {
+    if (!product || typeof product !== 'object') return null;
+    const name =
+      (product as any).name || (product as any).title || 'F.A.S. Motorsports Product';
+    const slug = typeof (product as any).slug === 'string' ? (product as any).slug : undefined;
+    const priceRaw = (product as any).price;
+    const priceValue =
+      typeof priceRaw === 'number'
+        ? priceRaw.toFixed(2)
+        : typeof priceRaw === 'string'
+        ? priceRaw.replace(/[^0-9.]/g, '')
+        : undefined;
+    const productUrl = slug ? `${canonicalHome}shop/${slug}` : canonicalHome;
+    const image = typeof (product as any).imageUrl === 'string' ? (product as any).imageUrl : undefined;
+
+    const offers = priceValue
+      ? {
+          '@type': 'Offer',
+          priceCurrency: 'USD',
+          price: priceValue,
+          availability: 'https://schema.org/InStock',
+          url: productUrl
+        }
+      : undefined;
+
+    return {
+      '@type': 'Product',
+      '@id': `#fas-product-${index + 1}`,
+      name,
+      image: image ? [image] : undefined,
+      description: `${name} available through F.A.S. Motorsports with in-house support and validation.`,
+      brand: { '@type': 'Organization', name: 'F.A.S. Motorsports' },
+      url: productUrl,
+      offers
+    };
+  })
+  .filter(Boolean);
+
+const structuredDataGraph = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    organizationSchema,
+    localBusinessSchema,
+    webSiteSchema,
+    webPageSchema,
+    ...productSchemas
+  ]
+};
 ---
 
 
 <BaseLayout
   title="Performance Parts, Wheels & Packages"
   description="F.A.S. Motorsports — premium performance upgrades, billet parts, custom fabrication, and wheel packages for Hellcat, Trackhawk, TRX and more."
-  canonical={`${new URL(Astro.request.url).origin}/`}
+  canonical={canonicalHome}
   ogImage="https://fasmotorsports.com/images/social/social-share.webp"
+  keywords={[
+    'F.A.S. Motorsports',
+    'Fort Myers performance shop',
+    'Hellcat performance parts',
+    'Trackhawk upgrades',
+    'TRX packages',
+    'custom fabrication',
+    'billet supercharger parts',
+    'performance wheel packages'
+  ]}
 >
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={JSON.stringify(structuredDataGraph)} />
+  </Fragment>
 
     <div aria-hidden="true" class="hidden" {...inlineFieldAttrs('title')}>
       {pageDoc?.title ?? 'Home'}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -225,7 +225,7 @@ const productSchemas = featuredProductsNormalized
       '@id': `#fas-product-${index + 1}`,
       name,
       image: image ? [image] : undefined,
-      description: `${name} available through F.A.S. Motorsports with in-house support and validation.`,
+      description: (product as any).description || `${name} available through F.A.S. Motorsports with in-house support and validation.`,
       brand: { '@type': 'Organization', name: 'F.A.S. Motorsports' },
       url: productUrl,
       offers

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -141,7 +141,7 @@ const localBusinessSchema = {
   '@id': '#fas-location',
   name: 'F.A.S. Motorsports',
   url: canonicalHome,
-  telephone: '(812) 200-9012',
+  telephone: '(239) 200-9012',
   email: 'sales@fasmotorsports.com',
   image: 'https://fasmotorsports.com/images/social/social-share.webp',
   address: {


### PR DESCRIPTION
## Summary
- add default author, description, and keyword metadata plus breadcrumb JSON-LD in the base layout
- provide keyword support and canonical handling for pages consuming the layout
- inject organization, local business, website, and product schema data on the homepage for richer SEO coverage

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6902e03e8770832cbf83c0a82dc46321