### PR TITLE
Allow server visual editing origin

### DIFF
--- a/src/lib/sanity-utils.ts
+++ b/src/lib/sanity-utils.ts
@@ -162,7 +162,9 @@ const isHostnameAllowlisted = (hostname: string | null | undefined): boolean => 
   return visualEditingAllowedHosts.has(normalized);
 };
 
-const visualEditingOriginAllowed = isHostnameAllowlisted(runtimeHostname);
+const visualEditingOriginAllowed = isBrowserRuntime
+  ? isHostnameAllowlisted(runtimeHostname)
+  : true; // Allow server-side rendering to honor request-level hostname checks
 
 const visualEditingRequested = toBooleanFlag(
   import.meta.env.PUBLIC_SANITY_ENABLE_VISUAL_EDITING as string | undefined


### PR DESCRIPTION
## Summary
- ensure server-side rendering treats missing runtime hostname as allowlisted so visual editing flags remain active
- keep hostname allowlist checks for browser environments intact

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6902f43b69c8832cb38bb35ebf34af67