### PR TITLE
Fix UTC parsing for shipping estimator dates

### DIFF
--- a/src/components/cart/ShippingEstimator.tsx
+++ b/src/components/cart/ShippingEstimator.tsx
@@ -31,8 +31,22 @@ function startOfDay(date: Date) {
 
 function parseEstimatedDeliveryDate(value?: string | null): Date | null {
   if (!value) return null;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  if (typeof value === 'string' && value.includes('T')) {
+    const utcYear = parsed.getUTCFullYear();
+    const utcMonth = parsed.getUTCMonth();
+    const utcDate = parsed.getUTCDate();
+
+    const normalized = new Date(utcYear, utcMonth, utcDate);
+    if (!Number.isNaN(normalized.getTime())) {
+      return normalized;
+    }
+  }
+
+  return parsed;
 }
 
 function normalizeDeliveryDays(value: unknown): number | null {


### PR DESCRIPTION
## Summary
- normalize estimated delivery timestamps from ShipEngine so they are interpreted as the intended calendar date in the shopper's locale

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6902f436fde4832c9b1054d23e60f3c5