### PR TITLE
Add local TTF fallbacks ahead of CDN fonts

### DIFF
--- a/src/styles/fas-theme.css
+++ b/src/styles/fas-theme.css
@@ -12,6 +12,7 @@
     local('American Captain'),
     url('/fonts/AmericanCaptain.woff2') format('woff2'),
     url('/fonts/AmericanCaptain.woff') format('woff'),
+    url('/fonts/AmericanCaptain.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/AmericanCaptain.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/AmericanCaptain.woff') format('woff');
   font-weight: normal;
@@ -25,6 +26,7 @@
     local('Ethnocentric'),
     url('/fonts/Ethnocentric-Regular.woff2') format('woff2'),
     url('/fonts/Ethnocentric-Regular.woff') format('woff'),
+    url('/fonts/Ethnocentric-Regular.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/Ethnocentric-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Ethnocentric-Regular.woff') format('woff');
   font-weight: normal;
@@ -38,6 +40,7 @@
     local('Ethnocentric Italic'),
     url('/fonts/Ethnocentric-Italic.woff2') format('woff2'),
     url('/fonts/Ethnocentric-Italic.woff') format('woff'),
+    url('/fonts/Ethnocentric-Italic.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/Ethnocentric-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Ethnocentric-Italic.woff') format('woff');
   font-weight: normal;
@@ -51,6 +54,7 @@
     local('Kwajong'),
     url('/fonts/Kwajong.woff2') format('woff2'),
     url('/fonts/Kwajong.woff') format('woff'),
+    url('/fonts/Kwajong.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/Kwajong.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Kwajong.woff') format('woff');
   font-weight: normal;
@@ -64,6 +68,7 @@
     local('Kwajong Italic'),
     url('/fonts/Kwajong-Italic.woff2') format('woff2'),
     url('/fonts/Kwajong-Italic.woff') format('woff'),
+    url('/fonts/Kwajong-Italic.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/Kwajong-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Kwajong-Italic.woff') format('woff');
   font-weight: normal;
@@ -77,6 +82,7 @@
     local('Cyber Princess'),
     url('/fonts/CyberPrincess-Regular.woff2') format('woff2'),
     url('/fonts/CyberPrincess-Regular.woff') format('woff'),
+    url('/fonts/CyberPrincess-Regular.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess-Regular.woff') format('woff');
   font-style: normal;
@@ -90,6 +96,7 @@
     local('Cyber Princess Italic'),
     url('/fonts/CyberPrincess-Italic.woff2') format('woff2'),
     url('/fonts/CyberPrincess-Italic.woff') format('woff'),
+    url('/fonts/CyberPrincess-Italic.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess-Italic.woff') format('woff');
   font-style: italic;
@@ -103,6 +110,7 @@
     local('Cyber Princess 3D'),
     url('/fonts/CyberPrincess3D-Regular.woff2') format('woff2'),
     url('/fonts/CyberPrincess3D-Regular.woff') format('woff'),
+    url('/fonts/CyberPrincess3D-Regular.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Regular.woff') format('woff');
   font-weight: normal;
@@ -116,6 +124,7 @@
     local('Cyber Princess 3D Italic'),
     url('/fonts/CyberPrincess3D-Italic.woff2') format('woff2'),
     url('/fonts/CyberPrincess3D-Italic.woff') format('woff'),
+    url('/fonts/CyberPrincess3D-Italic.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Italic.woff') format('woff');
   font-weight: normal;
@@ -129,6 +138,7 @@
     local('Cyber Princess 3D Filled'),
     url('/fonts/CyberPrincess3DFilled-Regular.woff2') format('woff2'),
     url('/fonts/CyberPrincess3DFilled-Regular.woff') format('woff'),
+    url('/fonts/CyberPrincess3DFilled-Regular.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Regular.woff') format('woff');
   font-weight: normal;
@@ -142,6 +152,7 @@
     local('Cyber Princess 3D Filled Italic'),
     url('/fonts/CyberPrincess3DFilled-Italic.woff2') format('woff2'),
     url('/fonts/CyberPrincess3DFilled-Italic.woff') format('woff'),
+    url('/fonts/CyberPrincess3DFilled-Italic.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Italic.woff') format('woff');
   font-weight: normal;
@@ -155,6 +166,7 @@
     local('Borgsquad Italic'),
     url('/fonts/BorgsquadItalic.woff2') format('woff2'),
     url('/fonts/BorgsquadItalic.woff') format('woff'),
+    url('/fonts/borgsquadital.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/BorgsquadItalic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/BorgsquadItalic.woff') format('woff');
   font-weight: normal;
@@ -167,6 +179,7 @@
     local('Borgsquad'),
     url('/fonts/Borgsquad.woff2') format('woff2'),
     url('/fonts/Borgsquad.woff') format('woff'),
+    url('/fonts/borgsquad.ttf') format('truetype'),
     url('https://www.fasmotorsports.com/fonts/Borgsquad.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Borgsquad.woff') format('woff');
   font-weight: normal;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,8 +76,9 @@ table {
   src:
     local('American Captain'),
     url('/fonts/AmericanCaptain.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/AmericanCaptain.woff2') format('woff2'),
     url('/fonts/AmericanCaptain.woff') format('woff'),
+    url('/fonts/AmericanCaptain.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/AmericanCaptain.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/AmericanCaptain.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -89,8 +90,9 @@ table {
   src:
     local('Ethnocentric'),
     url('/fonts/Ethnocentric-Regular.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/Ethnocentric-Regular.woff2') format('woff2'),
     url('/fonts/Ethnocentric-Regular.woff') format('woff'),
+    url('/fonts/Ethnocentric-Regular.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/Ethnocentric-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Ethnocentric-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -102,8 +104,9 @@ table {
   src:
     local('Ethnocentric Italic'),
     url('/fonts/Ethnocentric-Italic.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/Ethnocentric-Italic.woff2') format('woff2'),
     url('/fonts/Ethnocentric-Italic.woff') format('woff'),
+    url('/fonts/Ethnocentric-Italic.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/Ethnocentric-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Ethnocentric-Italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
@@ -115,8 +118,9 @@ table {
   src:
     local('Kwajong'),
     url('/fonts/Kwajong.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/Kwajong.woff2') format('woff2'),
     url('/fonts/Kwajong.woff') format('woff'),
+    url('/fonts/Kwajong.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/Kwajong.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Kwajong.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -128,8 +132,9 @@ table {
   src:
     local('Kwajong Italic'),
     url('/fonts/Kwajong-Italic.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/Kwajong-Italic.woff2') format('woff2'),
     url('/fonts/Kwajong-Italic.woff') format('woff'),
+    url('/fonts/Kwajong-Italic.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/Kwajong-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Kwajong-Italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
@@ -141,8 +146,9 @@ table {
   src:
     local('Cyber Princess'),
     url('/fonts/CyberPrincess-Regular.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/CyberPrincess-Regular.woff2') format('woff2'),
     url('/fonts/CyberPrincess-Regular.woff') format('woff'),
+    url('/fonts/CyberPrincess-Regular.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/CyberPrincess-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess-Regular.woff') format('woff');
   font-style: normal;
   font-weight: normal;
@@ -154,8 +160,9 @@ table {
   src:
     local('Cyber Princess Italic'),
     url('/fonts/CyberPrincess-Italic.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/CyberPrincess-Italic.woff2') format('woff2'),
     url('/fonts/CyberPrincess-Italic.woff') format('woff'),
+    url('/fonts/CyberPrincess-Italic.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/CyberPrincess-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess-Italic.woff') format('woff');
   font-style: italic;
   font-weight: normal;
@@ -167,8 +174,9 @@ table {
   src:
     local('Cyber Princess 3D'),
     url('/fonts/CyberPrincess3D-Regular.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Regular.woff2') format('woff2'),
     url('/fonts/CyberPrincess3D-Regular.woff') format('woff'),
+    url('/fonts/CyberPrincess3D-Regular.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -180,8 +188,9 @@ table {
   src:
     local('Cyber Princess 3D Italic'),
     url('/fonts/CyberPrincess3D-Italic.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Italic.woff2') format('woff2'),
     url('/fonts/CyberPrincess3D-Italic.woff') format('woff'),
+    url('/fonts/CyberPrincess3D-Italic.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3D-Italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
@@ -193,8 +202,9 @@ table {
   src:
     local('Cyber Princess 3D Filled'),
     url('/fonts/CyberPrincess3DFilled-Regular.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Regular.woff2') format('woff2'),
     url('/fonts/CyberPrincess3DFilled-Regular.woff') format('woff'),
+    url('/fonts/CyberPrincess3DFilled-Regular.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Regular.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -206,8 +216,9 @@ table {
   src:
     local('Cyber Princess 3D Filled Italic'),
     url('/fonts/CyberPrincess3DFilled-Italic.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Italic.woff2') format('woff2'),
     url('/fonts/CyberPrincess3DFilled-Italic.woff') format('woff'),
+    url('/fonts/CyberPrincess3DFilled-Italic.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Italic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/CyberPrincess3DFilled-Italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
@@ -219,8 +230,9 @@ table {
   src:
     local('Borgsquad Italic'),
     url('/fonts/BorgsquadItalic.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/BorgsquadItalic.woff2') format('woff2'),
     url('/fonts/BorgsquadItalic.woff') format('woff'),
+    url('/fonts/borgsquadital.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/BorgsquadItalic.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/BorgsquadItalic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
@@ -232,8 +244,9 @@ table {
   src:
     local('Borgsquad'),
     url('/fonts/Borgsquad.woff2') format('woff2'),
-    url('https://www.fasmotorsports.com/fonts/Borgsquad.woff2') format('woff2'),
     url('/fonts/Borgsquad.woff') format('woff'),
+    url('/fonts/borgsquad.ttf') format('truetype'),
+    url('https://www.fasmotorsports.com/fonts/Borgsquad.woff2') format('woff2'),
     url('https://www.fasmotorsports.com/fonts/Borgsquad.woff') format('woff');
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
## Summary
- reorder each `@font-face` declaration so local WOFF assets are listed before CDN URLs
- add local TTF fallbacks so browsers without WOFF support still avoid CDN requests

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6902f42fbb2c832c8582a14266157d9d