### PR TITLE
fix: normalise audit URLs and route prefixes

### DIFF
--- a/scripts/seo/auditLinks.ts
+++ b/scripts/seo/auditLinks.ts
@@ -39,16 +39,21 @@ const SITE_BASE_URL = resolveSiteBaseUrl();
 
 const normalizeAuditUrl = (href: string): string | null => {
   if (!href) return null;
-  if (/^https?:\/\//i.test(href)) return href;
-  if (/^\/\//.test(href)) return `https:${href}`;
-  if (href.startsWith('/')) {
-    try {
-      return new URL(href, SITE_BASE_URL).toString();
-    } catch {
-      return null;
-    }
+
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (/^\/\//.test(trimmed)) return `https:${trimmed}`;
+
+  // Bail out on non-http schemes such as mailto:, tel:, data:, javascript:, etc.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
+
+  try {
+    return new URL(trimmed, SITE_BASE_URL).toString();
+  } catch {
+    return null;
   }
-  return null;
 };
 
 export async function auditLinks(options: AuditLinksOptions = {}) {

--- a/src/lib/seoData.ts
+++ b/src/lib/seoData.ts
@@ -114,6 +114,26 @@ interface RawRelatedLink {
 
 const isHttpUrl = (value: string) => /^https?:\/\//i.test(value);
 
+const ROUTE_PREFIX_MATCHERS: Array<{ pattern: RegExp; prefix: string }> = [
+  { pattern: /(product|vehicle|inventory)/, prefix: '/shop' },
+  { pattern: /(category|collection)/, prefix: '/shop/categories' },
+  { pattern: /(article|blog|post|news)/, prefix: '/blog' },
+  { pattern: /(service|repair)/, prefix: '/services' }
+];
+
+const resolveRoutePrefix = (...identifiers: Array<string | null | undefined>) => {
+  for (const identifier of identifiers) {
+    const normalized = (identifier ?? '').toLowerCase();
+    if (!normalized) continue;
+    for (const { pattern, prefix } of ROUTE_PREFIX_MATCHERS) {
+      if (pattern.test(normalized)) {
+        return prefix;
+      }
+    }
+  }
+  return '';
+};
+
 const normalizeRelatedLink = (
   link: RawRelatedLink
 ): { label: string; href?: string } | null => {
@@ -137,20 +157,8 @@ const normalizeRelatedLink = (
     return { label, href: rawHref };
   }
 
-  const identifier = (link.source ?? link.docType ?? '').toLowerCase();
-
-  const pickPrefix = () => {
-    if (identifier.includes('product')) return '/shop';
-    if (identifier.includes('category')) return '/shop/categories';
-    if (identifier.includes('article') || identifier.includes('blog') || identifier.includes('post')) {
-      return '/blog';
-    }
-    if (identifier.includes('service')) return '/services';
-    return '';
-  };
-
-  const prefix = pickPrefix();
   const sanitized = rawHref.replace(/^\/+/, '');
+  const prefix = resolveRoutePrefix(link.docType, link.source);
   const sanitizedPrefix = prefix.replace(/^\/+|\/+$/g, '');
   const lowerSanitized = sanitized.toLowerCase();
 


### PR DESCRIPTION
## Summary
- ensure the link audit script normalizes relative hrefs against the site base URL and ignores non-http schemes
- add reusable route prefix resolution so related links from Sanity gain the correct /shop, /blog, etc. path segments

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_6902f8bf5c48832c9718223e992a0ea2