### PR TITLE
Update .us domain redirect to canonical .com host

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,16 +5,14 @@
 
 # Legacy domain + WooCommerce URL redirects consolidated from public/_redirects
 [[redirects]]
-  from = "https://fasmotorsports.us/*"
-  to = "https://www.fasmotorsports.com/:splat"
+  from = "/*"
+  to = "https://fasmotorsports.com/:splat"
   status = 301
   force = true
-
-[[redirects]]
-  from = "https://www.fasmotorsports.us/*"
-  to = "https://www.fasmotorsports.com/:splat"
-  status = 301
-  force = true
+  conditions = { Host = [
+    "fasmotorsports.us",
+    "www.fasmotorsports.us"
+  ] }
 
 [[redirects]]
   from = "/product/2-4l-2-7l-snout-porting"


### PR DESCRIPTION
## Summary
- replace the individual fasmotorsports.us redirect rules with a host-conditioned catch-all
- send all traffic from the .us domains to https://fasmotorsports.com while preserving the path

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_690852813db4832ca0a2c3d4d5c94ccd