### PR TITLE
Fix moment locale resolution for Stripe client build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -190,7 +190,8 @@ export default defineConfig({
         '@pages': fileURLToPath(new URL('./src/pages', import.meta.url)),
         '@lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
         lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
-        unframer$: fileURLToPath(new URL('./src/lib/unframer-shim.ts', import.meta.url))
+        unframer$: fileURLToPath(new URL('./src/lib/unframer-shim.ts', import.meta.url)),
+        moment$: fileURLToPath(new URL('./src/lib/moment-shim.ts', import.meta.url))
       }
     },
     server: {

--- a/src/lib/moment-shim.ts
+++ b/src/lib/moment-shim.ts
@@ -1,0 +1,30 @@
+import moment from 'moment/moment';
+
+function safeSetLocale(locale: string) {
+  try {
+    moment.locale(locale);
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('[moment-shim] Failed to set moment locale', { locale, error });
+    }
+  }
+}
+
+// Ensure we have at least the built-in English locale active immediately.
+safeSetLocale('en');
+
+// Attempt to preload the richer "en" locale data bundled with moment.
+void (async () => {
+  try {
+    await import('moment/locale/en');
+    safeSetLocale('en');
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('[moment-shim] Failed to preload moment locale "en". Falling back to default.', error);
+    }
+    // Locale is already set to 'en' above, so nothing else to do.
+  }
+})();
+
+export * from 'moment/moment';
+export default moment;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
       "@pages/*": ["src/pages/*"],
-      "@lib/*": ["src/lib/*"]
+      "@lib/*": ["src/lib/*"],
+      "moment": ["src/lib/moment-shim.ts"]
     },
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- add a shim that preloads moment's English locale and falls back to the built-in default when loading fails
- alias moment to the shim in Astro/Vite and TypeScript config so dependencies resolve the locale-safe build

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_690d1127e390832cbdab2b872e677fa4