### PR TITLE
Add desktop add-to-cart toast notification

### DIFF
--- a/src/components/LayoutSelector.jsx
+++ b/src/components/LayoutSelector.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import MobileBaseLayout from '../layouts/MobileBaseLayout';
+import MobileAddToCartToast from './cart/MobileAddToCartToast';
+import DesktopAddToCartToast from './cart/DesktopAddToCartToast';
 
 function LayoutSelector({ children }) {
   const [isMobile, setIsMobile] = useState(false);
@@ -8,7 +10,15 @@ function LayoutSelector({ children }) {
     setIsMobile(window.innerWidth < 768);
   }, []);
 
-  return isMobile ? <MobileBaseLayout>{children}</MobileBaseLayout> : <>{children}</>;
+  const content = isMobile ? <MobileBaseLayout>{children}</MobileBaseLayout> : <>{children}</>;
+
+  return (
+    <>
+      {content}
+      <MobileAddToCartToast />
+      <DesktopAddToCartToast />
+    </>
+  );
 }
 
 export default LayoutSelector;

--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -78,6 +78,11 @@ const imageUrl = resolveSanityImageUrl([productImage, product?.images]) ?? fallb
     }
 
     function showProductToast(message, success = true) {
+      try {
+        if (window.matchMedia('(max-width: 768px)').matches) {
+          return;
+        }
+      } catch {}
       let toast = document.getElementById('product-toast');
       if (!toast) {
         toast = document.createElement('div');
@@ -111,6 +116,16 @@ const imageUrl = resolveSanityImageUrl([productImage, product?.images]) ?? fallb
       }
       cart.items = items;
       saveCart(cart);
+
+      try {
+        window.dispatchEvent(
+          new CustomEvent('fas:add-to-cart-success', { detail: { name: item?.name } })
+        );
+      } catch {
+        try {
+          window.dispatchEvent(new Event('fas:add-to-cart-success'));
+        } catch {}
+      }
     }
 
     // Event delegation for all .add-to-cart buttons

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -2,6 +2,7 @@ import { resolveSanityImageUrl, type Product as SanityProduct } from '@lib/sanit
 import { cn } from '@components/ui/utils';
 import { addItem } from '@lib/cart';
 import { prefersDesktopCart } from '@/lib/device';
+import { emitAddToCartSuccess } from '@/lib/add-to-cart-toast';
 import '../styles/global.css';
 
 export interface ProductCardProps {
@@ -48,12 +49,20 @@ function addToCart(product: SanityProduct) {
     const productUrl = slug ? `/shop/${slug}` : undefined;
     addItem({ id, name, price, quantity: 1, categories, image, productUrl });
 
+    emitAddToCartSuccess({ name });
+
     if (typeof window !== 'undefined') {
       try {
-        const eventName = prefersDesktopCart() ? 'open-desktop-cart' : 'open-cart';
-        window.dispatchEvent(new Event(eventName));
+        if (!prefersDesktopCart()) {
+          window.dispatchEvent(new Event('open-cart'));
+        }
       } catch (err) {
-        window.dispatchEvent(new Event('open-cart'));
+        void err;
+        try {
+          window.dispatchEvent(new Event('open-cart'));
+        } catch {
+          // ignore
+        }
       }
     }
   } catch (e) {

--- a/src/components/cart/DesktopAddToCartToast.tsx
+++ b/src/components/cart/DesktopAddToCartToast.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Transition } from '@headlessui/react';
+import { CheckCircleIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon } from '@heroicons/react/20/solid';
+import { ADD_TO_CART_SUCCESS_EVENT, type AddToCartToastDetail } from '@/lib/add-to-cart-toast';
+
+const AUTO_HIDE_MS = 2800;
+const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
+
+export default function DesktopAddToCartToast() {
+  const [mounted, setMounted] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [detail, setDetail] = useState<AddToCartToastDetail | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const labelId = useMemo(
+    () => `desktop-add-to-cart-toast-${Math.random().toString(36).slice(2, 10)}`,
+    []
+  );
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const media = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const handleChange = () => setIsDesktop(media.matches);
+
+    handleChange();
+    media.addEventListener('change', handleChange);
+
+    return () => {
+      media.removeEventListener('change', handleChange);
+    };
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const handleSuccess = (event: Event) => {
+      if (!isDesktop) return;
+
+      const customEvent = event as CustomEvent<AddToCartToastDetail>;
+      setDetail(customEvent?.detail ?? null);
+      setOpen(true);
+
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => setOpen(false), AUTO_HIDE_MS);
+    };
+
+    window.addEventListener(ADD_TO_CART_SUCCESS_EVENT, handleSuccess as EventListener);
+
+    return () => {
+      window.removeEventListener(ADD_TO_CART_SUCCESS_EVENT, handleSuccess as EventListener);
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [mounted, isDesktop]);
+
+  useEffect(() => {
+    if (!mounted || !open) return;
+
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => setOpen(false), AUTO_HIDE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [open, mounted]);
+
+  const close = () => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setOpen(false);
+  };
+
+  if (!mounted) return null;
+
+  return (
+    <div
+      aria-live="assertive"
+      className="pointer-events-none fixed inset-0 z-[150] flex items-end justify-end px-6 pb-6"
+    >
+      <Transition
+        show={isDesktop && open}
+        enter="transform transition ease-out duration-200"
+        enterFrom="translate-y-2 opacity-0"
+        enterTo="translate-y-0 opacity-100"
+        leave="transform transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
+      >
+        <div className="pointer-events-auto">
+          <div
+            role="alert"
+            aria-atomic="true"
+            aria-labelledby={`${labelId}-title`}
+            aria-hidden={!open}
+            className="w-full min-w-[280px] max-w-[320px] rounded-lg border border-[rgba(255,255,255,0.07)] bg-[rgba(12,12,12,0.85)] px-3 py-3 shadow-[0_0_15px_rgba(56,189,255,0.25)] backdrop-blur-sm"
+            style={{ fontFamily: "'Roboto', 'Inter', sans-serif" }}
+          >
+            <div className="flex items-start gap-2">
+              <CheckCircleIcon aria-hidden="true" className="h-5 w-5 text-[#5ab8ff]" />
+              <div className="flex-1 pt-0.5 text-sm">
+                <p id={`${labelId}-title`} className="text-[14px] font-semibold text-white">
+                  Item added to cart
+                </p>
+                {detail?.name ? (
+                  <p className="sr-only">{detail.name}</p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={close}
+                className="rounded-full p-1 text-white transition hover:text-neutral-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/30"
+              >
+                <span className="sr-only">Close notification</span>
+                <XMarkIcon aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="mt-3 flex justify-end">
+              <a
+                href="/cart"
+                className="inline-flex h-[30px] items-center rounded-md bg-[#5ab8ff] px-3 py-1 text-[12px] font-semibold text-black shadow-[0_4px_10px_-6px_rgba(56,189,255,0.5)] transition hover:bg-[#74c5ff] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#74c5ff]"
+              >
+                View Cart
+              </a>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </div>
+  );
+}

--- a/src/components/cart/MobileAddToCartToast.tsx
+++ b/src/components/cart/MobileAddToCartToast.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ADD_TO_CART_SUCCESS_EVENT, type AddToCartToastDetail } from '@/lib/add-to-cart-toast';
+
+const AUTO_HIDE_DELAY = 2500;
+const MOBILE_QUERY = '(max-width: 768px)';
+
+export default function MobileAddToCartToast() {
+  const [mounted, setMounted] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [detail, setDetail] = useState<AddToCartToastDetail | null>(null);
+  const hideTimer = useRef<number | null>(null);
+  const labelId = useMemo(
+    () => `mobile-add-to-cart-toast-${Math.random().toString(36).slice(2, 10)}`,
+    []
+  );
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const media = window.matchMedia(MOBILE_QUERY);
+    const handleChange = () => setIsMobile(media.matches);
+
+    handleChange();
+    media.addEventListener('change', handleChange);
+
+    return () => {
+      media.removeEventListener('change', handleChange);
+    };
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const handleSuccess = (event: Event) => {
+      if (!isMobile) return;
+
+      const customEvent = event as CustomEvent<AddToCartToastDetail>;
+      setDetail(customEvent?.detail || null);
+      setVisible(true);
+
+      if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
+      hideTimer.current = window.setTimeout(() => {
+        setVisible(false);
+      }, AUTO_HIDE_DELAY);
+    };
+
+    window.addEventListener(ADD_TO_CART_SUCCESS_EVENT, handleSuccess as EventListener);
+
+    return () => {
+      window.removeEventListener(ADD_TO_CART_SUCCESS_EVENT, handleSuccess as EventListener);
+      if (hideTimer.current !== null) {
+        window.clearTimeout(hideTimer.current);
+        hideTimer.current = null;
+      }
+    };
+  }, [mounted, isMobile]);
+
+  useEffect(() => {
+    if (!mounted || !visible) return;
+
+    if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
+    hideTimer.current = window.setTimeout(() => {
+      setVisible(false);
+    }, AUTO_HIDE_DELAY);
+
+    return () => {
+      if (hideTimer.current !== null) {
+        window.clearTimeout(hideTimer.current);
+        hideTimer.current = null;
+      }
+    };
+  }, [visible, mounted]);
+
+  if (!mounted || !isMobile) return null;
+
+  const close = () => {
+    if (hideTimer.current !== null) {
+      window.clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+    setVisible(false);
+  };
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-[140] flex justify-center px-4 pb-5">
+      <div
+        className={`flex w-full max-w-[360px] justify-center transition-all duration-200 ease-out ${
+          visible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+        }`}
+        style={{ pointerEvents: visible ? 'auto' : 'none' }}
+      >
+        <div
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+          aria-labelledby={`${labelId}-title`}
+          aria-hidden={!visible}
+          className="flex w-full items-start gap-2 rounded-[12px] border border-[rgba(255,255,255,0.07)] bg-[rgba(12,12,12,0.85)] px-3.5 py-3 shadow-[0_0_15px_rgba(56,189,255,0.25)] backdrop-blur-sm"
+          style={{ fontFamily: 'Inter, Roboto, sans-serif' }}
+        >
+          <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center">
+            <svg className="h-5 w-5 text-[#5ab8ff]" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M6 12l4 4 8-8"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+
+          <div className="flex-1 text-[13px] leading-tight text-white">
+            <p id={`${labelId}-title`} className="text-sm font-semibold text-white">
+              Item added to cart
+            </p>
+            {detail?.name ? <p className="sr-only">{detail.name}</p> : null}
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <a
+                href="/cart"
+                className="inline-flex items-center justify-center rounded-md bg-[#5ab8ff] px-3 py-1.5 text-xs font-semibold text-black shadow-[0_4px_10px_rgba(56,189,255,0.18)] transition hover:bg-[#7dc9ff] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7dc9ff]"
+              >
+                View Cart
+              </a>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={close}
+            className="ml-1 rounded-full p-1 text-white transition hover:text-neutral-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+          >
+            <span className="sr-only">Close add to cart notification</span>
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M6 6l12 12M18 6L6 18"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/cart/add-to-cart.tsx
+++ b/src/components/cart/add-to-cart.tsx
@@ -4,6 +4,7 @@ import { PlusIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import { addItem } from '@components/cart/actions';
 import { prefersDesktopCart } from '@/lib/device';
+import { emitAddToCartSuccess } from '@/lib/add-to-cart-toast';
 import * as React from 'react';
 
 /**
@@ -140,12 +141,19 @@ export function AddToCart({ product }: { product: any }) {
       productUrl
     });
 
+    emitAddToCartSuccess({ name: product?.title });
+
     try {
-      const eventName = prefersDesktopCart() ? 'open-desktop-cart' : 'open-cart';
-      window.dispatchEvent(new Event(eventName));
+      if (!prefersDesktopCart()) {
+        window.dispatchEvent(new Event('open-cart'));
+      }
     } catch (error) {
       void error;
-      window.dispatchEvent(new Event('open-cart'));
+      try {
+        window.dispatchEvent(new Event('open-cart'));
+      } catch {
+        // ignore
+      }
     }
   }
 

--- a/src/components/cart/cart-context.tsx
+++ b/src/components/cart/cart-context.tsx
@@ -11,6 +11,7 @@ import {
   clearCart as clearCartAction,
   redirectToCheckout as checkoutAction
 } from '@components/cart/actions';
+import { emitAddToCartSuccess } from '@/lib/add-to-cart-toast';
 
 /**
  * Cart Context — FAS (Astro + Sanity + localStorage)
@@ -83,6 +84,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
 
   async function addCartItem(item: Partial<CartItem> & { id: string; quantity?: number }) {
     await addItemAction(null as any, item);
+    emitAddToCartSuccess({ name: item?.name });
     // actions.ts will emit cart:changed; no need to manually setCart
   }
 

--- a/src/components/storefront/ProductQuickViewButton.tsx
+++ b/src/components/storefront/ProductQuickViewButton.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { EyeIcon, ShoppingCartIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { addItem } from '@components/cart/actions';
 import { prefersDesktopCart } from '@/lib/device';
+import { emitAddToCartSuccess } from '@/lib/add-to-cart-toast';
 
 export type QuickViewProduct = {
   id?: string;
@@ -86,9 +87,21 @@ export default function ProductQuickViewButton({
         productUrl: product.href
       });
 
-      const eventName = prefersDesktopCart() ? 'open-desktop-cart' : 'open-cart';
+      emitAddToCartSuccess({ name: product.title });
+
       if (typeof window !== 'undefined') {
-        window.dispatchEvent(new Event(eventName));
+        try {
+          if (!prefersDesktopCart()) {
+            window.dispatchEvent(new Event('open-cart'));
+          }
+        } catch (error) {
+          void error;
+          try {
+            window.dispatchEvent(new Event('open-cart'));
+          } catch {
+            // ignore
+          }
+        }
       }
     } catch (error) {
       console.error('Failed to add item from quick view:', error);

--- a/src/lib/add-to-cart-toast.ts
+++ b/src/lib/add-to-cart-toast.ts
@@ -1,0 +1,19 @@
+export const ADD_TO_CART_SUCCESS_EVENT = 'fas:add-to-cart-success';
+
+export type AddToCartToastDetail = {
+  name?: string;
+};
+
+export function emitAddToCartSuccess(detail?: AddToCartToastDetail) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.dispatchEvent(
+      new CustomEvent<AddToCartToastDetail>(ADD_TO_CART_SUCCESS_EVENT, {
+        detail: detail ?? {}
+      })
+    );
+  } catch {
+    window.dispatchEvent(new Event(ADD_TO_CART_SUCCESS_EVENT));
+  }
+}


### PR DESCRIPTION
## Summary
- add a desktop-only add-to-cart toast that listens for the shared success event and matches the minimal FAS theme
- mount the desktop toast alongside the mobile toast so it renders globally without affecting other layouts
- limit automatic cart opening to mobile flows so desktop relies on the toast while existing cart logic remains unchanged

## Testing
- yarn lint
- yarn build
- yarn test (fails: script not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167eda43f4832cbf19b96173998bb8)