### PR TITLE
Restrict product fetches to active items

### DIFF
--- a/src/lib/sanity-utils.ts
+++ b/src/lib/sanity-utils.ts
@@ -32,9 +32,9 @@ const apiVersion = '2023-01-01';
 const imageBuilder = projectId && dataset ? imageUrlBuilder({ projectId, dataset }) : null;
 
 const SANITY_CDN_HOSTS = new Set(['cdn.sanity.io', 'cdn.sanityusercontent.com']);
-const ACTIVE_PRODUCT_FILTER =
+export const ACTIVE_PRODUCT_FILTER =
   '!(_id in path("drafts.**")) && lower(coalesce(status, "active")) == "active"';
-const ACTIVE_PRODUCT_WITH_SLUG_FILTER = `${ACTIVE_PRODUCT_FILTER} && defined(slug.current)`;
+export const ACTIVE_PRODUCT_WITH_SLUG_FILTER = `${ACTIVE_PRODUCT_FILTER} && defined(slug.current)`;
 const FEATURED_PRODUCT_FILTER = 'string(featured) == "true"';
 
 export interface SanityImageTransformOptions {

--- a/src/pages/api/products.ts
+++ b/src/pages/api/products.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@sanity/client';
 
+import { ACTIVE_PRODUCT_FILTER } from '@/lib/sanity-utils.ts';
+
 const projectId = import.meta.env.PUBLIC_SANITY_PROJECT_ID || import.meta.env.SANITY_PROJECT_ID;
 const token = import.meta.env.SANITY_API_TOKEN;
 
@@ -29,12 +31,7 @@ export async function GET({ url }: { url: URL }) {
   const tune = url.searchParams.get('tune');
   const minHp = url.searchParams.get('minHp');
 
-  const filters = [
-    `_type == "product"`,
-    `!(_id in path('drafts.**'))`,
-    `defined(slug.current)`,
-    `lower(coalesce(status, "active")) == "active"`
-  ];
+  const filters = [`_type == "product"`, ACTIVE_PRODUCT_FILTER, `defined(slug.current)`];
 
   if (category) filters.push(`"${category}" in categories[]->slug.current`);
   if (vehicle) filters.push(`"${vehicle}" in compatibleVehicles[]->slug.current`);


### PR DESCRIPTION
## Summary
- export the active product GROQ filter constants for reuse
- reuse the shared active-product filter in the products API route so only active items are returned

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691757679b80832caaaf1f69fbc6f53d)