### PR TITLE
Add attribution tracking and enrich checkout metadata

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -57,6 +57,8 @@ function addToCart(product: SanityProduct) {
       categories,
       image,
       productUrl,
+      selectedOptions: [],
+      selectedUpgrades: [],
       ...(shippingClass ? { shippingClass } : {}),
       ...(installOnly ? { installOnly: true } : {})
     });

--- a/src/components/cart/add-to-cart.tsx
+++ b/src/components/cart/add-to-cart.tsx
@@ -127,6 +127,9 @@ export function AddToCart({ product }: { product: any }) {
     const id = (variantId || product?._id || product?.id) as Maybe<string>;
     if (!id) return;
     const { shippingClass, installOnly } = resolveProductCartMeta(product);
+    const selectedOptionsList = Object.entries(selected).map(
+      ([key, value]) => `${key}: ${value}`
+    );
 
     await addItem(null as any, {
       id,
@@ -139,6 +142,8 @@ export function AddToCart({ product }: { product: any }) {
             : undefined,
       image: product?.images?.[0]?.asset?.url || product?.images?.[0]?.url,
       options: selected,
+      selectedOptions: selectedOptionsList,
+      selectedUpgrades: [],
       quantity: 1,
       productUrl,
       ...(shippingClass ? { shippingClass } : {}),

--- a/src/components/storefront/ProductQuickViewButton.tsx
+++ b/src/components/storefront/ProductQuickViewButton.tsx
@@ -239,6 +239,9 @@ export default function ProductQuickViewButton({
       const baseId = product.id || product.href || '';
       const resolvedId =
         baseId && selectionSignature ? `${baseId}::${selectionSignature}` : baseId || product.id;
+      const selectedOptionsList = selectionEntries.map(
+        (entry) => `${entry.groupTitle}: ${entry.label}`
+      );
       await addItem(null as any, {
         id: resolvedId || product.id,
         name: product.title,
@@ -247,6 +250,8 @@ export default function ProductQuickViewButton({
         quantity: 1,
         productUrl: product.href,
         options: optionsPayload,
+        selectedOptions: selectedOptionsList,
+        selectedUpgrades: [],
         ...(cartMeta.shippingClass ? { shippingClass: cartMeta.shippingClass } : {}),
         ...(cartMeta.installOnly ? { installOnly: true } : {})
       });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -744,5 +744,16 @@ const jsonLdEntries = [...defaultJsonLdEntries, ...cmsJsonLdEntries];
     <!-- fas-auth client shim (provides window.fasAuth) -->
     <script src="/fas-auth.js" defer></script>
     <!-- Auth bootstrap removed: serverless login/session handles auth without Auth0 SDK -->
+    <script>
+      // Capture landing page on first visit
+      if (!sessionStorage.getItem('landing_page')) {
+        sessionStorage.setItem('landing_page', window.location.href);
+      }
+
+      // Capture first touch timestamp
+      if (!sessionStorage.getItem('first_touch')) {
+        sessionStorage.setItem('first_touch', new Date().toISOString());
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -425,6 +425,19 @@ export async function POST({ request }: { request: Request }) {
   const clamp = (value: string, max = 500) =>
     value.length > max ? value.slice(0, max) : value;
 
+  const normalizeMetadataMap = (input?: Record<string, unknown> | null) => {
+    if (!input || typeof input !== 'object') return {} as Record<string, string>;
+    return Object.entries(input).reduce<Record<string, string>>((acc, [key, value]) => {
+      if (!key) return acc;
+      const normalizedKey = key.trim();
+      if (!normalizedKey) return acc;
+      const strValue = value == null ? '' : String(value);
+      if (!strValue.trim()) return acc;
+      acc[normalizedKey] = clamp(strValue.trim());
+      return acc;
+    }, {});
+  };
+
   const formatSelectedOptions = (
     input?: Record<string, unknown> | null,
     selectionsRaw?: unknown
@@ -786,8 +799,11 @@ export async function POST({ request }: { request: Request }) {
       site: baseUrl
     };
 
+    const attributionMetadata = normalizeMetadataMap((body as any)?.metadata || (body as any)?.attribution);
+
     const metadataForSession: Record<string, string> = {
       ...baseMetadata,
+      ...attributionMetadata,
       ...(cartSummary ? { cart_summary: cartSummary } : {}),
       ...(metaCart ? { cart: metaCart } : {})
     };


### PR DESCRIPTION
## Summary
- add client-side attribution capture to the base layout
- capture cart option selections and attribution data before starting checkout
- forward attribution metadata into the checkout API to keep Stripe and Sanity in sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d25dd68c832c8325e2fe0105576b)