### PR TITLE
Fix excessive top spacing on homepage

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -728,7 +728,7 @@ const jsonLdEntries = [...defaultJsonLdEntries, ...cmsJsonLdEntries];
     <!-- Page content -->
     <div class="relative flex flex-col flex-1">
       <main
-        class="px-5 mt-24 sm:mt-28 lg:mt-32 pt-6 flex-1 container max-w-full mx-auto with-header-offset"
+        class="px-5 pt-6 flex-1 container max-w-full mx-auto with-header-offset"
       >
         {breadcrumbItems.length > 0 && <Breadcrumbs items={breadcrumbItems} />}
         <slot />


### PR DESCRIPTION
## Summary
- remove redundant top margin from layout main container to rely on header offset utility

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ac4240838832c97abe315bd6a400c)