### PR TITLE
Capture option and upgrade details in Sanity orders

### DIFF
--- a/netlify/functions/stripe-webhook.ts
+++ b/netlify/functions/stripe-webhook.ts
@@ -337,6 +337,7 @@ export const handler: Handler = async (event) => {
               const metadata: Record<string, unknown> = {};
               if (l?.o) metadata.option_summary = l.o;
               if (l?.u) metadata.upgrades = l.u;
+              if (typeof l?.ut === 'number') metadata.upgrades_total = l.ut;
               if (l?.meta && typeof l.meta === 'object') {
                 Object.assign(metadata, l.meta as Record<string, unknown>);
               }

--- a/src/server/sanity/order-cart.ts
+++ b/src/server/sanity/order-cart.ts
@@ -6,6 +6,10 @@ export type OrderCartItem = {
   name?: string;
   price: number;
   quantity: number;
+  optionSummary?: string;
+  optionDetails?: string[];
+  upgrades?: string[];
+  upgradesTotal?: number;
   categories?: string[];
   image?: string;
   productUrl?: string;
@@ -38,6 +42,98 @@ const generateKey = (): string => {
   return `oc_${stamp}_${rand}`;
 };
 
+const parseOptionDetails = (metadata?: Record<string, unknown>): { summary?: string; details?: string[] } => {
+  if (!metadata) return {};
+  const meta = metadata as Record<string, unknown>;
+
+  const optionSummary = toStringOrUndefined(
+    meta['option_summary'] ?? meta['selected_options'] ?? meta['options_readable']
+  );
+  const optionDetailString = toStringOrUndefined(meta['Options Detail'] ?? meta['options_detail']);
+
+  const detailSet: Set<string> = new Set();
+  const pushDetail = (value?: string | null) => {
+    if (!value) return;
+    const trimmed = value.trim();
+    if (trimmed) detailSet.add(trimmed);
+  };
+
+  const parseJsonDetails = (json?: unknown) => {
+    if (typeof json !== 'string' || !json.trim()) return;
+    try {
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        Object.entries(parsed as Record<string, unknown>).forEach(([key, value]) => {
+          const label = key.trim();
+          const val = value == null ? '' : String(value).trim();
+          if (label && val) pushDetail(`${label}: ${val}`);
+        });
+      }
+    } catch {
+      void 0;
+    }
+  };
+
+  parseJsonDetails(meta['option_details_json'] || meta['selected_options_json']);
+
+  const optionNameRegex = /^option(\d+)_name$/i;
+  Object.keys(metadata).forEach((key) => {
+    const match = key.match(optionNameRegex);
+    if (!match) return;
+    const idx = match[1];
+    const name = toStringOrUndefined(meta[key]);
+    const value = toStringOrUndefined(meta[`option${idx}_value`]);
+    if (name && value) pushDetail(`${name}: ${value}`);
+  });
+
+  if (!detailSet.size && optionSummary) {
+    optionSummary
+      .split(/[•|]/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .forEach((entry) => pushDetail(entry));
+  }
+
+  if (!detailSet.size && optionDetailString) {
+    optionDetailString
+      .split('|')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .forEach((entry) => pushDetail(entry));
+  }
+
+  return { summary: optionSummary, details: detailSet.size ? Array.from(detailSet) : undefined };
+};
+
+const parseUpgrades = (metadata?: Record<string, unknown>): { list?: string[]; total?: number } => {
+  if (!metadata) return {};
+  const meta = metadata as Record<string, unknown>;
+  const values = new Set<string>();
+  const addFromString = (input?: unknown) => {
+    if (typeof input !== 'string') return;
+    input
+      .split(/[|,]/)
+      .map((v) => v.trim())
+      .filter(Boolean)
+      .forEach((v) => values.add(v));
+  };
+
+  addFromString(meta['upgrades']);
+  addFromString(meta['upgrades_readable']);
+  addFromString(meta['upgrade_list']);
+  addFromString(meta['upgrade_titles']);
+
+  Object.keys(meta)
+    .filter((key) => /^upgrade_\d+$/i.test(key))
+    .forEach((key) => addFromString(meta[key]));
+
+  const total = toNumber(
+    meta['upgrades_total'] ?? meta['upgrade_total'] ?? meta['upgradesTotal'] ?? meta['upgradeTotal']
+  );
+
+  return { list: values.size ? Array.from(values) : undefined, total: total ?? undefined };
+};
+
 export function createOrderCartItem(data: {
   id?: unknown;
   sku?: unknown;
@@ -67,6 +163,9 @@ export function createOrderCartItem(data: {
       ? (data.metadata as Record<string, unknown>)
       : undefined;
 
+  const { summary: optionSummary, details: optionDetails } = parseOptionDetails(metadata);
+  const { list: upgradeList, total: upgradesTotal } = parseUpgrades(metadata);
+
   return {
     _type: 'orderCartItem',
     _key: generateKey(),
@@ -75,6 +174,10 @@ export function createOrderCartItem(data: {
     name: toStringOrUndefined(data.name) || toStringOrUndefined(data.description),
     price: price ?? 0,
     quantity: quantity ?? 1,
+    ...(optionSummary ? { optionSummary } : {}),
+    ...(optionDetails && optionDetails.length ? { optionDetails } : {}),
+    ...(upgradeList && upgradeList.length ? { upgrades: upgradeList } : {}),
+    ...(typeof upgradesTotal === 'number' ? { upgradesTotal } : {}),
     ...(categories && categories.length ? { categories } : {}),
     ...(image ? { image } : {}),
     ...(productUrl ? { productUrl } : {}),


### PR DESCRIPTION
## Summary
- calculate upgrade totals during checkout and include them in Stripe metadata and compact cart payloads
- enrich webhook cart item parsing to persist option details, upgrades, and upgrade totals into Sanity order items

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ac65d9074832cb043089e1b018913)