### PR TITLE
Require email capture for Stripe checkout sessions

### DIFF
--- a/netlify/functions/stripe-webhook.ts
+++ b/netlify/functions/stripe-webhook.ts
@@ -301,7 +301,7 @@ export const handler: Handler = async (event) => {
       }
 
       // Find or create Sanity customer
-      const email = session.customer_details?.email || '';
+      const email = session.customer_details?.email || session.customer_email || '';
       // Prefer userId from session metadata if provided during Checkout
       let userId: string | undefined = (session.metadata as any)?.userId || undefined;
       let customerRef: { _type: 'reference'; _ref: string } | undefined;
@@ -540,7 +540,7 @@ export const handler: Handler = async (event) => {
         collectedShippingDetails
           ? {
               address: collectedShippingDetails.address,
-              email: session.customer_details?.email ?? null,
+              email: email || null,
               name: collectedShippingDetails.name,
               phone: session.customer_details?.phone ?? null,
               tax_exempt: session.customer_details?.tax_exempt ?? null,

--- a/src/components/vendor-portal/OrdersPage.tsx
+++ b/src/components/vendor-portal/OrdersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 type LineItem = {
   name?: string;
@@ -40,7 +40,7 @@ const OrdersPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -54,12 +54,11 @@ const OrdersPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [statusFilter]);
 
   useEffect(() => {
-    load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter]);
+    void load();
+  }, [load]);
 
   const total = useMemo(() => {
     const sum = orders.reduce((acc, order) => {

--- a/src/components/vendor-portal/VendorPostContent.tsx
+++ b/src/components/vendor-portal/VendorPostContent.tsx
@@ -15,7 +15,7 @@ const components: Partial<PortableTextReactComponents> = {
         href={(value as any)?.href}
         className="text-primary hover:underline"
         target="_blank"
-        rel="noopener"
+        rel="noreferrer noopener"
       >
         {children}
       </a>

--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -1039,7 +1039,7 @@ export async function POST({ request }: { request: Request }) {
       tax_id_collection: { enabled: true },
       // Enable Stripe Tax for automatic sales tax calculation
       automatic_tax: { enabled: true },
-      billing_address_collection: 'auto',
+      billing_address_collection: 'required',
       phone_number_collection: { enabled: true },
       shipping_address_collection: shippingAddressCollection,
       success_url: `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
@@ -1056,7 +1056,7 @@ export async function POST({ request }: { request: Request }) {
       delete (sessionParams.payment_intent_data as { shipping?: unknown }).shipping;
     }
 
-    sessionParams.customer_creation = 'if_required';
+    sessionParams.customer_creation = 'always';
     if (customerEmail) {
       sessionParams.customer_email = customerEmail;
     }

--- a/src/pages/api/webhooks.ts
+++ b/src/pages/api/webhooks.ts
@@ -255,7 +255,7 @@ export async function POST({ request }: { request: Request }) {
       // Find or create a Customer document
       let customerRef: { _type: 'reference'; _ref: string } | undefined;
       let userId: string | undefined = userIdFromMetadata;
-      const email = session.customer_details?.email || '';
+      const email = session.customer_details?.email || session.customer_email || '';
       if (email) {
         const existing = await sanity.fetch(
           `*[_type=="customer" && lower(email)==lower($email)][0]{_id,emailMarketing,marketingOptIn,emailOptIn}`,
@@ -361,7 +361,7 @@ export async function POST({ request }: { request: Request }) {
         collectedShippingDetails
           ? {
               address: collectedShippingDetails.address,
-              email: session.customer_details?.email ?? null,
+              email: email || null,
               name: collectedShippingDetails.name,
               phone: session.customer_details?.phone ?? null,
               tax_exempt: session.customer_details?.tax_exempt ?? null,
@@ -397,7 +397,7 @@ export async function POST({ request }: { request: Request }) {
           typeof session.shipping_cost?.amount_total === 'number'
             ? session.shipping_cost.amount_total / 100
             : undefined,
-        customerEmail: session.customer_details?.email || '',
+        customerEmail: email,
         customer: customerRef,
         userId,
         cart: cartLines,
@@ -407,7 +407,7 @@ export async function POST({ request }: { request: Request }) {
         shippingAddress: {
           name: session.customer_details?.name || '',
           phone: session.customer_details?.phone || '',
-          email: session.customer_details?.email || '',
+          email,
           addressLine1: session.customer_details?.address?.line1 || '',
           addressLine2: session.customer_details?.address?.line2 || '',
           city: session.customer_details?.address?.city || '',


### PR DESCRIPTION
## Summary
- require Stripe Checkout to collect billing details and create a customer for every session so email addresses are captured
- ensure webhook handlers pull fallback customer emails from Stripe sessions when persisting data to Sanity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69411a2b1a48832c9ec5018fc2015c5a)