### PR TITLE
Improve mobile header spacing and contrast

### DIFF
--- a/src/components/divider/brandDivider.tsx
+++ b/src/components/divider/brandDivider.tsx
@@ -16,7 +16,7 @@ function BrandDivider({ className }: BrandDividerProps) {
       )}
     >
       <div className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-gradient-to-r from-white/10 via-white/5 to-transparent px-4 py-2 backdrop-blur-sm">
-        <span className="font-borg text-primaryB text-base sm:text-xl">F.a.S.</span>
+        <span className="font-borg text-primary text-base sm:text-xl">F.a.S.</span>
         <span className="font-ethno text-white text-base sm:text-xl">Motorsports</span>
       </div>
     </section>

--- a/src/components/header/header2.astro
+++ b/src/components/header/header2.astro
@@ -16,7 +16,7 @@ import DesktopCart from '@/components/cart/DesktopCart.tsx';
   <!-- Mobile Header -->
   <div
     id="mheader"
-    class="md:hidden w-full bg-dark/60 backdrop-blur-md shadow-md shadow-primary/20 relative flex items-center justify-between px-4 h-14"
+    class="md:hidden w-full bg-black backdrop-blur-md shadow-md shadow-primary/20 relative flex items-center justify-between px-4 h-14"
   >
     <!-- Mobile menu toggle -->
     <button
@@ -95,7 +95,7 @@ import DesktopCart from '@/components/cart/DesktopCart.tsx';
   <!-- Desktop Header -->
   <div
     id="dheader"
-    class="hidden rounded-full border border-white/5 border-shadow shadow-inner drop-shadow-md backdrop-blur-sm bg-dark/40 shadow-white/10 md:block px-10 mx-10"
+    class="hidden rounded-full border border-white/5 border-shadow shadow-inner drop-shadow-md backdrop-blur-sm bg-black shadow-white/10 md:block px-10 mx-10"
   >
     <div
       class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-3 items-center h-16"

--- a/src/components/hero/homeHero.tsx
+++ b/src/components/hero/homeHero.tsx
@@ -46,7 +46,7 @@ export default function HomeHero() {
   return (
     <section
       id="homeHero"
-      className="relative flex items-center justify-center pt-10 pb-6 mb-12 sm:mb-16 lg:mb-[-8px]"
+      className="relative flex items-center justify-center pt-6 pb-4 sm:pt-10 sm:pb-6 mb-12 sm:mb-16 lg:mb-[-8px]"
     >
       <div className="relative w-full overflow-hidden rounded-none min-h-[420px] sm:min-h-[520px] lg:min-h-[620px]">
         {/* Video Background */}


### PR DESCRIPTION
## Summary
- reduce mobile hero padding to tighten space beneath the header
- switch the F.A.S. badge color to the primary brand hue
- set header backgrounds to solid black for stronger navigation and cart contrast

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694278f3bf20832c97092f273092486a)