### PR TITLE
Improve mobile width for product drop section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -169,7 +169,7 @@ const structuredDataGraph =
       </section>
 
       <section
-        class="mx-20 px-2 py-2 border border-primary/20 shadow-card-outter border-spacing-1 shadow-white/30 shadow-inner rounded-lg ring-offset-70 ring-1 ring-primary/10 hover:shadow-card-inner hover:shadow-white/50 transition-shadow duration-300"
+        class="mx-0 sm:mx-4 md:mx-10 lg:mx-20 px-2 py-2 border border-primary/20 shadow-card-outter border-spacing-1 shadow-white/30 shadow-inner rounded-lg ring-offset-70 ring-1 ring-primary/10 hover:shadow-card-inner hover:shadow-white/50 transition-shadow duration-300"
         id="PowerstrokePipingKit"
       >
         <PowerstrokePipingKit />


### PR DESCRIPTION
## Summary
- adjust homepage Powerstroke Piping Kit section margins to allow full-width display on mobile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942793e6274832cb30fa8a8229b6ade)