### PR TITLE
Handle ssh2 native module in Netlify bundling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -755,8 +755,11 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
-  external_node_modules = ["sharp"]
-  included_files = ["node_modules/sharp/**/*"]
+  external_node_modules = ["sharp", "ssh2"]
+  included_files = [
+    "node_modules/sharp/**/*",
+    "node_modules/ssh2/lib/protocol/crypto/build/Release/**"
+  ]
 
 # Help Netlify Dev choose the right framework command
 [dev]

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "sharp": "^0.33.5",
     "solid-js": "^1.9.6",
     "sonner": "2.0.3",
+    "ssh2": "^1.17.0",
     "ssh2-sftp-client": "^10.0.3",
     "stripe": "^18.4.0",
     "styled-components": "^6.1.17",


### PR DESCRIPTION
## Summary
- add ssh2 as an explicit dependency
- configure Netlify functions bundling to keep ssh2 external and include its native binary files

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69428c78f2fc832cb47622f6a6d698b9)